### PR TITLE
Don't update seed string in the UI

### DIFF
--- a/MM2RandoHost/ViewModels/MainWindowViewModel.cs
+++ b/MM2RandoHost/ViewModels/MainWindowViewModel.cs
@@ -62,7 +62,6 @@ namespace MM2RandoHost.ViewModels
 
             // Get A-Z representation of seed
             string seedAlpha = SeedConvert.ConvertBase10To26(RandomMM2.Seed);
-            RandoSettings.SeedString = seedAlpha;
             Debug.WriteLine("\nSeed: " + seedAlpha + "\n");
 
             // Create log file if left shift is pressed while clicking

--- a/MM2RandoHost/ViewModels/MainWindowViewModel.cs
+++ b/MM2RandoHost/ViewModels/MainWindowViewModel.cs
@@ -62,6 +62,10 @@ namespace MM2RandoHost.ViewModels
 
             // Get A-Z representation of seed
             string seedAlpha = SeedConvert.ConvertBase10To26(RandomMM2.Seed);
+            if (seed < 0)
+            {
+                RandoSettings.SeedString = seedAlpha;
+            }
             Debug.WriteLine("\nSeed: " + seedAlpha + "\n");
 
             // Create log file if left shift is pressed while clicking


### PR DESCRIPTION
After studying the base26 conversion code and testing some things, I realized something about the way it parses the input strings.

In particular, before when we'd enter a seed like, "I LIKE PIZZA" then the input box for the seed would change. It had accepted the seed just fine and replaced the text with the base26 rendering of that seed. Characters that are out side of the base26 range (so for example, space, digits, or punctuation), are just treated as -1.

This patch changes the UI so that when you enter a seed and click the generate button, it doesn't update. If you request a random seed, it will update that text box (making it easier to share the seed).