### PR TITLE
Add option to disable screen flashing.

### DIFF
--- a/MM2RandoLib/RandoSettings.cs
+++ b/MM2RandoLib/RandoSettings.cs
@@ -33,6 +33,7 @@ namespace MM2Randomizer
             this.IsWeaponNamesRandom = true;
             this.IsColorsRandom = true;
             this.IsBGMRandom = true;
+            this.IsFlashingDisabled = true;
             this.SelectedPlayer = PlayerSprite.Rockman;
 
             // Flags for Optional Gameplay Modules
@@ -238,6 +239,8 @@ namespace MM2Randomizer
         /// 
         /// </summary>
         public Boolean IsWeaponNamesRandom { get; set; }
+
+        public bool IsFlashingDisabled { get; set; }
 
         /// <summary>
         /// TODO

--- a/MM2RandoLib/RandomMM2.cs
+++ b/MM2RandoLib/RandomMM2.cs
@@ -103,7 +103,7 @@ namespace MM2Randomizer
             rWeaponNames = new RText();
 
             // Independent
-            randomColors = new RColors();
+            randomColors = new RColors(Settings.IsFlashingDisabled);
 
             // Independent
             randomMusic = new RMusic();
@@ -177,7 +177,7 @@ namespace MM2Randomizer
                 CosmeticRandomizers.Add(rWeaponNames);
             }
 
-                
+
             // Instantiate RNG object r based on RandomMM2.Seed
             InitializeSeed();
 
@@ -228,6 +228,11 @@ namespace MM2Randomizer
             if (Settings.BurstChaserMode)
             {
                 MiscHacks.SetBurstChaser(Patch);
+            }
+
+            if (Settings.IsFlashingDisabled)
+            {
+                MiscHacks.DisableScreenFlashing(Patch, Settings);
             }
 
             MiscHacks.SetHitPointChargingSpeed(Patch, Settings.HitPointChargingSpeed);

--- a/MM2RandoLib/Randomizers/Colors/RColors.cs
+++ b/MM2RandoLib/Randomizers/Colors/RColors.cs
@@ -15,7 +15,11 @@ namespace MM2Randomizer.Randomizers.Colors
     {
         private static int MegaManColorAddressU = 0x03d314;
 
-        public RColors() { }
+        private bool flashing_disabled;
+
+        public RColors(bool flashing_disabled) {
+            this.flashing_disabled = flashing_disabled;
+        }
 
         public void Randomize(Patch p, Random r)
         {
@@ -624,11 +628,17 @@ namespace MM2Randomizer.Randomizers.Colors
             // choose front color
             rColor = r.Next(mediumOnly.Count);
             shade0 = mediumOnly[rColor];
-            shade1 = (byte)(shade0 + 0x20);
+            shade1 = (byte)(shade0 + 0x10);
+            shade2 = (byte)(shade1 + 0x20);
 
             p.Add(0x02D7D1, shade0, "Wily Machine Red 1 Color"); // 0x15
             p.Add(0x02D7D9, shade0, "Wily Machine Red 2 Color"); // 0x15
-            p.Add(0x02D7D3, shade1, "Wily Machine Light Red 1 Color"); // 0x15
+            p.Add(0x02D7D3, shade2, "Wily Machine Light Red 1 Color"); // 0x15
+            if (flashing_disabled)
+            {
+                p.Add(0x2DA94, shade1, "Wily Machine Flash Color");
+                p.Add(0x2DA21, shade2, "Wily Machine Restore Color");
+            }
 
             // Dragon
             // choose orange replacement
@@ -643,6 +653,11 @@ namespace MM2Randomizer.Randomizers.Colors
             p.Add(0x02CF97, shade2, "Dragon Orange Color 2");
             p.Add(0x0034C6, shade3, "Dragon Orange Mouth");
             p.Add(0x0034C7, shade2, "Dragon Orange Color 3");
+            if (flashing_disabled)
+            {
+                p.Add(0x002D1B0, shade3, "Dragon Hit Flash Color");
+                p.Add(0x002D185, shade2, "Dragon Hit Restore Color");
+            }
 
             // Choose green replacement
             rColor = r.Next(darkOnly.Count);

--- a/MM2RandoLib/Utilities/MiscHacks.cs
+++ b/MM2RandoLib/Utilities/MiscHacks.cs
@@ -220,6 +220,49 @@ namespace MM2Randomizer.Utilities
             }
         }
 
+        internal static void DisableScreenFlashing(Patch p, RandoSettings settings)
+        {
+            p.Add(0x3412E, 0x1F, "Disable Stage Select Flashing");
+            p.Add(0x3596D, 0x0F, "Wily Map Flash Color");
+            if (!settings.FastText)
+                // This sequence is disabled by FastText, and the patch conflicts with it.
+                p.Add(0x37C98, 0x0F, "Item Get Flash Color");
+
+            p.Add(0x2C9FF, 0x0F, "Flash Man Fire Flash Color");
+            p.Add(0x2CC7C, 0x0F, "Metal Man Periodic Flash Color");
+
+            p.Add(0x37A18, 0xEA, "NOP Ending Palette Flash");
+            p.Add(0x377AB, 0x00, "Disable Ending Screen Flash");
+
+            // Dragon
+            p.Add(0x2D1B2, 0x63, "Dragon Hit Flash Palette Index");
+            p.Add(0x2D187, 0x63, "Dragon Hit Restore Palette Index");
+            if (!settings.IsColorsRandom)
+            {
+                p.Add(0x2D1B0, 0x37, "Dragon Hit Flash Color");
+                p.Add(0x2D185, 0x27, "Dragon Hit Restore Color");
+            }
+            p.Add(0x2D3A0, 0x0F, "Dragon Defeat Flash Color");
+
+            // Guts Tank
+            p.Add(0x2D661, 0x5C, "Guts Tank Flash Palette Index");
+            // p.Add(0x2D65F, 0x0F, "Guts Tank Flash Color");
+
+            // Wily Machine
+            p.Add(0x2DA96, 0x63, "Wily Machine Flash Palette Index");
+            p.Add(0x2DA23, 0x63, "Wily Machine Restore Palette Index");
+            if (!settings.IsColorsRandom)
+            {
+                p.Add(0x2DA94, 0x25, "Wily Machine Flash Color");
+                p.Add(0x2DA21, 0x35, "Wily Machine Restore Color");
+            }
+
+            // Alien
+            p.Add(0x2DC97, 0x0F, "Alien Hit Flash Color");
+            p.Add(0x2DD6C, 0x0F, "Alien Defeat Flash Color");
+            p.Add(0x2DF1B, 0x0F, "Alien Explision Flash Color");
+        }
+
         public static void SetFastReadyText(Patch p)
         {
             p.Add(0x038147, 0x60, "READY Text Delay");

--- a/RandomizerHost/Views/MainWindow.axaml
+++ b/RandomizerHost/Views/MainWindow.axaml
@@ -399,6 +399,11 @@
                             Name="CheckBox_TextContent"
                             Content="Random Text Content"
                             IsChecked="{Binding Path=RandoSettings.IsWeaponNamesRandom}"/>
+
+                      <CheckBox
+                          Name="CheckBox_DisableFlashing"
+                          Content="Disable Screen Flashing"
+                          IsChecked="{Binding Path=RandoSettings.IsFlashingDisabled}"/>
                     </StackPanel>
 
                     <!-- Custom Sprite Selection -->


### PR DESCRIPTION
I haven't added this to the flags because I'm unsure of the implications of changing the string size.

Dragon and Guts Tank both flash to indicate taking damage, I changed this to flash part of their bodies, but this requires knowing their palettes which complicates things. If this isn't desired, we can change to just disabling flashing on those fights. (I wanted to do the same thing in the alien fight but couldn't get it to work.)

Although I tested the individual changes which I then ported over to the randomizer code, I haven't had a chance to test much in ROMs generated by the randomizer.
