### PR TITLE
Fix design of PreventETankUseAtFullLife

### DIFF
--- a/MM2RandoLib/RandomizationContext.cs
+++ b/MM2RandoLib/RandomizationContext.cs
@@ -321,6 +321,8 @@ namespace MM2Randomizer
                 this.Patch,
                 this.ActualizedBehaviorSettings.ChargingSpeedOption.WeaponEnergy);
 
+            // PreventETankUseAtFullLife must be applied before SetEnergyTankChargingSpeed
+            MiscHacks.PreventETankUseAtFullLife(this.Patch);
             MiscHacks.SetEnergyTankChargingSpeed(
                 this.Patch,
                 this.ActualizedBehaviorSettings.ChargingSpeedOption.EnergyTank);
@@ -337,7 +339,6 @@ namespace MM2Randomizer
             MiscHacks.SetWily5NoMusicChange(this.Patch);
             MiscHacks.NerfDamageValues(this.Patch);
             MiscHacks.SetETankKeep(this.Patch);
-            MiscHacks.PreventETankUseAtFullLife(this.Patch);
             MiscHacks.SetFastBossDefeatTeleport(this.Patch);
 
 

--- a/MM2RandoLib/Utilities/MiscHacks.cs
+++ b/MM2RandoLib/Utilities/MiscHacks.cs
@@ -481,7 +481,7 @@ namespace MM2Randomizer.Utilities
             // $9281: Menu Page and Menu Position Checking.        
             // $9292:A5 A7     LDA $00A7 ;$00A7 is ETankCount
             // $9294:F0 DE     BEQ $9274 ;Return if ETankCount == 0          
-            // $9296:C6 A7     DEC $00A7 ;Decrement ETankCount <=== Replacing this line.
+            // $9296:C6 A7     DEC $00A7 ;Decrement ETankCount
             // $9298:AD C0 06  LDA $06C0 ;$06C0 is Life
             // $929B:C9 1C     CMP #$1C
             // $929D:F0 D5     BEQ $9274 ;Return if Life == 28
@@ -500,49 +500,50 @@ namespace MM2Randomizer.Utilities
             //      ; Not sure what the next 2 commands are doing.
             //      ; Seem like part of the reglar game/draw loop since FrameCounter is updated.
             //      $92AD: 20 96 93 JSR $9396
-            //      $92B0: 20 AB C0 JSR $C0AB
+            //      $92B0: 20 AB C0 JSR $C0AB ;Wait for next frame
             //      $92B3: 4C 98 92 JMP $9298 ;Loop while (Life != 28)
             // }
 
-            // Change $9296 to call a subroutine. Choosing $BF77 for the location.
-            // $9296:20 77 BF   JSR $BF77
-            // ---
-            // $BF77:AD C0 06   LDA $06C0 ;$06C0 is Life
-            // $BF7A:C9 1C      CMP #$1C
-            // $BF7C:F0 02      BEQ $BF81 ;if(Life == 28) goto RTS
-            // $BF7E:C6 A7      DEC $00A7 ;Decrement ETankCount
-            // $BF81:60         RTS 
-
             Int32 prgOffset = 0x30010 - 0x4000;
-            // Inject new jump subroutine at 0D:9296 (should be 0x352A6).
-            Int32 jsrLocation = 0x9296 + prgOffset;
-
-            Byte[] jsrBytes = new Byte[]
+            Int32 patchLocation = 0x9296 + prgOffset;
+            Byte[] patchBytes = new Byte[]
             {
-                0x20, 0x77, 0xBF,   // JSR $BF77
+                0xAD, 0xC0, 0x06,   // LDA $6C0 ; Do not proceed if life is full
+                0xC9, 0x1C,         // CMP #$1C
+                0xF0, 0xD7,         // BEQ $9274
+
+                0xC6, 0xA7,         // DEC $A7 ; Decrement e-tanks
+
+                0xEE, 0xC0, 0x06,   // INC $6C0 ; Loop point: Increase life
+
+                0xA5, 0x1C,         // LDA $1C ; Load frame counter
+                0x20, 0x77, 0xBF,   // JSR $BF77 ; Call code that wouldn't fit here
+                0x20, 0x96, 0x93,   // JSR $9396 ; Do mostly ordinary stuff
+                0x20, 0xAB, 0xC0,   // JSR $C0AB
+
+                0xAD, 0xC0, 0x06,   // LDA $6C0 ; If life not full loop, else done
+                0xC9, 0x1C,         // CMP #$1C
+                0xF0, 0xC0,         // BEQ $9274
+                0xD0, 0xE9,         // BNE $929F
             };
 
-            for(Int32 offset = 0; offset < jsrBytes.Length; ++offset)
-            {
-                p.Add(jsrLocation + offset, jsrBytes[offset], "Prevent E-Tank Use at Full Life");
-            }
+            p.Add(patchLocation, patchBytes, "Prevent E-Tank Use at Full Life");
 
-            // Subroutine to decrement E-Tank Count. Skips decrement if Life == 28.
+            // Subroutine to play sound on ever 4th frame
             Byte[] eTankSubroutineBytes = new Byte[]
             {
-                0xAD, 0xC0, 0x06,       // LDA $06C0 ;$06C0 is Life
-                0xC9, 0x1C,             // CMP #$1C
-                0xF0, 0x02,             // BEQ 2 ;if(Life == 28) goto RTS
-                0xC6, 0xA7,             // DEC $00A7 ;Decrement ETankCount
-                0x60,                   // RTS 
+                0x29, 0x03,         // AND #$3
+                0xD0, 0x05,         // BNE $BF80
+
+                0xA9, 0x28,         // LDA #$28
+                0x4C, 0x51, 0xC0,   // JMP $C051
+
+                0x60,               // RTS
             };
 
             // Start at 0D:BF77 (should be 0x37F87).
-            Int32 etankLocation = 0xBF77 + prgOffset;
-            for(Int32 offset = 0; offset < eTankSubroutineBytes.Length; ++offset)
-            {
-                p.Add(etankLocation + offset, eTankSubroutineBytes[offset], "Prevent E-Tank Use at Full Life");
-            }
+            Int32 etankSubLocation = 0xBF77 + prgOffset;
+            p.Add(etankSubLocation, eTankSubroutineBytes, "Prevent E-Tank Use at Full Life");
         }
 
         /// <summary>

--- a/MM2RandoLib/Utilities/MiscHacks.cs
+++ b/MM2RandoLib/Utilities/MiscHacks.cs
@@ -500,7 +500,7 @@ namespace MM2Randomizer.Utilities
             //      ; Not sure what the next 2 commands are doing.
             //      ; Seem like part of the reglar game/draw loop since FrameCounter is updated.
             //      $92AD: 20 96 93 JSR $9396
-            //      $92B0: 20 AB C0 JSR $C0AB ;Wait for next frame
+            //      $92B0: 20 AB C0 JSR $C0AB ;Wait for next frame and update controller
             //      $92B3: 4C 98 92 JMP $9298 ;Loop while (Life != 28)
             // }
 
@@ -532,10 +532,10 @@ namespace MM2Randomizer.Utilities
             // Subroutine to play sound on ever 4th frame
             Byte[] eTankSubroutineBytes = new Byte[]
             {
-                0x29, 0x03,         // AND #$3
+                0x29, 0x03,         // AND #$3 ; If every 4th frame
                 0xD0, 0x05,         // BNE $BF80
 
-                0xA9, 0x28,         // LDA #$28
+                0xA9, 0x28,         // LDA #$28 ; Play life filling sound
                 0x4C, 0x51, 0xC0,   // JMP $C051
 
                 0x60,               // RTS

--- a/MM2RandoLib/Utilities/MiscHacks.cs
+++ b/MM2RandoLib/Utilities/MiscHacks.cs
@@ -513,32 +513,36 @@ namespace MM2Randomizer.Utilities
                 0xF0, 0xD7,         // BEQ $9274
 
                 0xC6, 0xA7,         // DEC $A7 ; Decrement e-tanks
+            
+                0xA5, 0x1C,         // LDA $1C ; 929F: Load frame counter
+                0x29, 0x03,         // AND #$3 ; If multiple of 4 frames increase life - THIS WILL BE PATCHED OVER
 
-                0xEE, 0xC0, 0x06,   // INC $6C0 ; Loop point: Increase life
-
-                0xA5, 0x1C,         // LDA $1C ; Load frame counter
                 0x20, 0x77, 0xBF,   // JSR $BF77 ; Call code that wouldn't fit here
                 0x20, 0x96, 0x93,   // JSR $9396 ; Do mostly ordinary stuff
                 0x20, 0xAB, 0xC0,   // JSR $C0AB
 
                 0xAD, 0xC0, 0x06,   // LDA $6C0 ; If life not full loop, else done
                 0xC9, 0x1C,         // CMP #$1C
-                0xF0, 0xC0,         // BEQ $9274
-                0xD0, 0xE9,         // BNE $929F
+                0xF0, 0xC1,         // BEQ $9274
+                0x4C, 0x9F, 0x92,   // JMP $929F
             };
 
             p.Add(patchLocation, patchBytes, "Prevent E-Tank Use at Full Life");
 
-            // Subroutine to play sound on ever 4th frame
             Byte[] eTankSubroutineBytes = new Byte[]
             {
-                0x29, 0x03,         // AND #$3 ; If every 4th frame
-                0xD0, 0x05,         // BNE $BF80
+                0xD0, 0x03,         // BNE $BF7C ; Skip life increase if nonzero
 
-                0xA9, 0x28,         // LDA #$28 ; Play life filling sound
+                0xEE, 0xC0, 0x06,   // INC $6C0 ; Increase life
+
+                0xA5, 0x1C,         // LDA $1C ; BF7C: If multiple of 4 frames...
+                0x29, 0x03,         // AND #$3
+                0xD0, 0x05,         // BNE $BF87
+
+                0xA9, 0x28,         // LDA #$28 ; ...play life filling sound
                 0x4C, 0x51, 0xC0,   // JMP $C051
 
-                0x60,               // RTS
+                0x60,               // RTS ; BF87
             };
 
             // Start at 0D:BF77 (should be 0x37F87).


### PR DESCRIPTION
The original implementation of PreventETankUseAtFullLife was very fragile, and depended on two critical things:

1. That the high byte of the injected subroutine address be the same as the opcode for LAX ($bf)
2. That the controller-reading function set Y to 0

mm2ft rewrote the controller-reading function to be DPCM safe, and in doing so it no longer sets Y to 0. This caused the LAX op to break, and things went downhill from there. This PR rewrites the PreventETankUseAtFullLife method to be fully robust and not depend on anything else.