### PR TITLE
Make compiler shut up about warning CS8524

### DIFF
--- a/MM2RandoLib/Randomizers/RItemGet.cs
+++ b/MM2RandoLib/Randomizers/RItemGet.cs
@@ -76,7 +76,7 @@ namespace MM2Randomizer.Randomizers
                     EItemNumber.One => "Item 1",
                     EItemNumber.Two => "Item 2",
                     EItemNumber.Three => "Item 3",
-                    EItemNumber.None => "",
+                    _ => "",
                 };
                 debug.AppendLine($"{i.Key.Name} stage\t -> {itemName}");
             }


### PR DESCRIPTION
Make compiler shut up about "MM2RandoLib\Randomizers\RItemGet.cs(74,43,74,49): warning CS8524: The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value. For example, the pattern '(MM2Randomizer.Enums.EItemNumber)3' is not covered."