### PR TITLE
Fix mm2ft crash on C2 tracks with non-max priority

### DIFF
--- a/MM2RandoLib/Randomizers/RMusic.cs
+++ b/MM2RandoLib/Randomizers/RMusic.cs
@@ -557,7 +557,9 @@ namespace MM2Randomizer.Randomizers
                     RebaseC2Song(song, bankIdx, songAddr);
 
                     // Write song header and data
-                    songStartRom = in_Patch.Add(songStartRom, song.SongHeader, $"Song Header for {song.SongName}");
+                    // Some tracks have priority < 0xf, which will break mm2ft. Force it to 0xf here
+                    var hdr = Enumerable.Prepend<Byte>(song.SongHeader.Skip(1), (Byte)0xf);
+                    songStartRom = in_Patch.Add(songStartRom, hdr, $"Song Header for {song.SongName}");
                     songStartRom = in_Patch.Add(songStartRom, song.SongData, $"Song Data for {song.SongName}");
                 }
             }


### PR DESCRIPTION
Fix the bug where C2 tracks with priority < 0xf cause mm2ft to crash.

This is caused by the order of operations in mm2ft when playing a C2 track:
1. Switch to the bank the C2 track is in, and store that as the current C2 bank
2. Call Mm2PlaySound
3. Mm2PlaySound checks the track priority and if >= the currently playing track plays it

This works fine for most C2 tracks, which use the priority 0xf (C1 tracks use the priority system, but it's rare in C2), but Duck Tales and 1 MM hack music use other priorities. There is no trivial way to make mm2ft detect whether Mm2PlaySound started the track or not, but MM2R can trivially force the priority of all tracks to 0xf.