### PR TITLE
Less ambiguous name for merciless mode

### DIFF
--- a/RandomizerHost/Views/MainWindow.axaml
+++ b/RandomizerHost/Views/MainWindow.axaml
@@ -741,7 +741,7 @@
                             IsEnabled="{Binding Path=AppConfigurationSettings.EnableSetting_MercilessMode}"
                         >
                             <CheckBox
-                                Content="Merciless One Hit Kill Mode"
+                                Content="Instant Death Ignores Invincibility"
                                 IsEnabled="{Binding !#ToggleSwitch_MercilessMode.IsChecked}"
                                 IsChecked="{Binding AppConfigurationSettings.MercilessMode}"
                             />


### PR DESCRIPTION
Rename "Merciless One Hit Kill Mode" option to "Instant Death Ignores Invincibility", since players couldn't tell what it actually did.