### PR TITLE
Upgrade projects to .NET 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        dotnet: ['6.0.x']
+        dotnet: ['8.0.x']
     name: Dotnet ${{ matrix.dotnet }} - ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release-builds.yml
+++ b/.github/workflows/release-builds.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        dotnet: ['6.0.x']
+        dotnet: ['8.0.x']
     name: Make Release
     steps:
       - uses: actions/checkout@v2

--- a/MM2RandoLib/MM2RandoLib.csproj
+++ b/MM2RandoLib/MM2RandoLib.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <SignAssembly>True</SignAssembly>
         <Title>MM2RandoLib</Title>
         <Version>0.6.6</Version>
@@ -33,7 +33,7 @@
       <DebugSymbols>true</DebugSymbols>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="System.Data.HashFunction.FNV" Version="2.0.0" />
       <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
       <PackageReference Include="Troschuetz.Random" Version="5.0.1" />

--- a/MM2RandoLib/Randomizers/RMusic.cs
+++ b/MM2RandoLib/Randomizers/RMusic.cs
@@ -308,7 +308,9 @@ namespace MM2Randomizer.Randomizers
             debug.AppendLine("Random Music Module");
             debug.AppendLine("--------------------------------------------");
 
+#nullable disable
             this.ImportMusic(in_Patch, in_Context.Seed, in_Context.ActualizedCosmeticSettings.CosmeticOption.OmitUnsafeMusicTracks == BooleanOption.True);
+#nullable restore
         }
 
         public void ImportMusic(Patch in_Patch, ISeed in_Seed, Boolean in_SafeOnly = false)

--- a/RandomizerHost/RandomizerHost.csproj
+++ b/RandomizerHost/RandomizerHost.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>RandomizerHost</AssemblyName>
     <ApplicationIcon>Assets\MegaMan2Randomizer.ico</ApplicationIcon>
     <PackageId>Mega Man 2 Randomizer</PackageId>
@@ -56,11 +56,11 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.19" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.19" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.19" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.19" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <PackageReference Include="Avalonia" Version="0.10.22" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.22" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.22" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.22" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MM2RandoLib\MM2RandoLib.csproj" />


### PR DESCRIPTION
.NET 6 is going out of support in November, and .NET 8 is the latest long term support (lol 3 years) version.

While I'm at it, also update
- Newtonsoft JSON to 13.0.3 (latest stable)
- Avalonia to 0.10.22 (the latest stable version of 0.10). I tried updating to the latest version (11.x), but got errors in things I wasn't familiar with, so I'll leave that to be someone else's problem.

This is for post-tournament builds, but I'm submitting it now so that I can use C# 12/.NET 8 in my work refactoring the music importing stuff into an independent library that can be shared by multiple randomizers (including Z1, Z2, and FF).