### PR TITLE
Redisable graphics that were previously absent from the graphics patch tables

### DIFF
--- a/MM2RandoLib/MM2RandoLib.csproj
+++ b/MM2RandoLib/MM2RandoLib.csproj
@@ -104,7 +104,6 @@
       <None Remove="Resources\SpritePatches\Bosses\BossDoorSign\BossDoorSign_GameMakerClown.ips" />
       <None Remove="Resources\SpritePatches\Bosses\BossDoorSign\BossDoorSign_GutsMan.ips" />
       <None Remove="Resources\SpritePatches\Bosses\BossDoorSign\BossDoorSign_Leo.ips" />
-      <None Remove="Resources\SpritePatches\Bosses\BossDoorSign\BossDoorSign_LilMac.ips" />
       <None Remove="Resources\SpritePatches\Bosses\BossDoorSign\BossDoorSign_MegaMan4Squid.ips" />
       <None Remove="Resources\SpritePatches\Bosses\BossDoorSign\BossDoorSign_MegaManMugshot.ips" />
       <None Remove="Resources\SpritePatches\Bosses\BossDoorSign\BossDoorSign_Metroid.ips" />
@@ -153,7 +152,6 @@
       <None Remove="Resources\SpritePatches\Bosses\FlashMan\FlashMan_RockMan2Plus.ips" />
       <None Remove="Resources\SpritePatches\Bosses\GutsTank\GutsTank_Bowser.ips" />
       <None Remove="Resources\SpritePatches\Bosses\GutsTank\GutsTank_Cray.ips" />
-      <None Remove="Resources\SpritePatches\Bosses\GutsTank\GutsTank_CutMansBadScissorsDay.ips" />
       <None Remove="Resources\SpritePatches\Bosses\GutsTank\GutsTank_Technodrome.ips" />
       <None Remove="Resources\SpritePatches\Bosses\HeatMan\HeatMan_Another.ips" />
       <None Remove="Resources\SpritePatches\Bosses\HeatMan\HeatMan_CutMansBadScissorsDay.ips" />
@@ -168,7 +166,6 @@
       <None Remove="Resources\SpritePatches\Bosses\MechaDragon\MechaDragon_Shades.ips" />
       <None Remove="Resources\SpritePatches\Bosses\MechaDragon\MechaDragon_Swag.ips" />
       <None Remove="Resources\SpritePatches\Bosses\MetalMan\MetalMan_CutMan.ips" />
-      <None Remove="Resources\SpritePatches\Bosses\MetalMan\MetalMan_CutMansBadScissorsDay.ips" />
       <None Remove="Resources\SpritePatches\Bosses\MetalMan\MetalMan_ElecMan.ips" />
       <None Remove="Resources\SpritePatches\Bosses\MetalMan\MetalMan_GrayZone.ips" />
       <None Remove="Resources\SpritePatches\Bosses\MetalMan\MetalMan_Peercast.ips" />
@@ -334,7 +331,6 @@
       <None Remove="Resources\SpritePatches\Environment\BossDoors\BossDoors_DK.ips" />
       <None Remove="Resources\SpritePatches\Environment\BossDoors\BossDoors_Link.ips" />
       <None Remove="Resources\SpritePatches\Environment\DestructibleBlock\DestructibleBlock_DoctorMarioV1.ips" />
-      <None Remove="Resources\SpritePatches\Environment\DestructibleBlock\DestructibleBlock_DoctorMarioV2.ips" />
       <None Remove="Resources\SpritePatches\Environment\DestructibleBlock\DestructibleBlock_SuperMarioBros3.ips" />
       <None Remove="Resources\SpritePatches\Environment\DestructibleBlock\DestructibleBlock_SuperMarioBros3V2.ips" />
       <None Remove="Resources\SpritePatches\Environment\DestructibleBlock\DestructibleBlock_SuperMarioBros3V3.ips" />
@@ -385,7 +381,6 @@
       <None Remove="Resources\SpritePatches\Environment\StageTiles\AirMan\Block\StageTile_AirMan_Block_Clear.ips" />
       <None Remove="Resources\SpritePatches\Environment\StageTiles\AirMan\Block\StageTile_AirMan_Block_Cloud.ips" />
       <None Remove="Resources\SpritePatches\Environment\StageTiles\AirMan\Goblin\StageTile_AirMan_Goblin_BabyMetroid.ips" />
-      <None Remove="Resources\SpritePatches\Environment\StageTiles\AirMan\Goblin\StageTile_AirMan_Goblin_CutmanBadScissorsDay.ips" />
       <None Remove="Resources\SpritePatches\Environment\StageTiles\AirMan\Goblin\StageTile_AirMan_Goblin_Gamma.ips" />
       <None Remove="Resources\SpritePatches\Environment\StageTiles\AirMan\Goblin\StageTile_AirMan_Goblin_Platform.ips" />
       <None Remove="Resources\SpritePatches\Environment\StageTiles\BubbleMan\Block\StageTile_BubbleMan_Block_DiveMan.ips" />
@@ -526,10 +521,8 @@
       <None Remove="Resources\SpritePatches\MenusAndTransitionScreens\StageSelectScreen\StageSelectScreen_BasicMaster.ips" />
       <None Remove="Resources\SpritePatches\MenusAndTransitionScreens\StageSelectScreen\StageSelectScreen_Claw.ips" />
       <None Remove="Resources\SpritePatches\MenusAndTransitionScreens\StageSelectScreen\StageSelectScreen_Exile.ips" />
-      <None Remove="Resources\SpritePatches\MenusAndTransitionScreens\StageSelectScreen\StageSelectScreen_FinalMix.ips" />
       <None Remove="Resources\SpritePatches\MenusAndTransitionScreens\StageSelectScreen\StageSelectScreen_None.ips" />
       <None Remove="Resources\SpritePatches\MenusAndTransitionScreens\StageSelectScreen\StageSelectScreen_Ultra.ips" />
-      <None Remove="Resources\SpritePatches\MenusAndTransitionScreens\TitleScreen\TitleScreen_FinalFantasy.ips" />
       <None Remove="Resources\SpritePatches\MenusAndTransitionScreens\WeaponGetScreen\WeaponGetScreen_Claw.ips" />
       <None Remove="Resources\SpritePatches\MenusAndTransitionScreens\WeaponGetScreen\WeaponGetScreen_FinalMix.ips" />
       <None Remove="Resources\SpritePatches\MenusAndTransitionScreens\WeaponGetScreen\WeaponGetScreen_MissingTile.ips" />
@@ -706,7 +699,6 @@
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\BossDoorSign\BossDoorSign_GameMakerClown.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\BossDoorSign\BossDoorSign_GutsMan.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\BossDoorSign\BossDoorSign_Leo.ips" />
-      <EmbeddedResource Include="Resources\SpritePatches\Bosses\BossDoorSign\BossDoorSign_LilMac.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\BossDoorSign\BossDoorSign_MegaMan4Squid.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\BossDoorSign\BossDoorSign_MegaManMugshot.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\BossDoorSign\BossDoorSign_Metroid.ips" />
@@ -755,7 +747,6 @@
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\FlashMan\FlashMan_RockMan2Plus.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\GutsTank\GutsTank_Bowser.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\GutsTank\GutsTank_Cray.ips" />
-      <EmbeddedResource Include="Resources\SpritePatches\Bosses\GutsTank\GutsTank_CutMansBadScissorsDay.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\GutsTank\GutsTank_Technodrome.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\HeatMan\HeatMan_Another.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\HeatMan\HeatMan_CutMansBadScissorsDay.ips" />
@@ -770,7 +761,6 @@
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\MechaDragon\MechaDragon_Shades.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\MechaDragon\MechaDragon_Swag.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\MetalMan\MetalMan_CutMan.ips" />
-      <EmbeddedResource Include="Resources\SpritePatches\Bosses\MetalMan\MetalMan_CutMansBadScissorsDay.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\MetalMan\MetalMan_ElecMan.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\MetalMan\MetalMan_GrayZone.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Bosses\MetalMan\MetalMan_Peercast.ips" />
@@ -936,7 +926,6 @@
       <EmbeddedResource Include="Resources\SpritePatches\Environment\BossDoors\BossDoors_DK.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Environment\BossDoors\BossDoors_Link.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Environment\DestructibleBlock\DestructibleBlock_DoctorMarioV1.ips" />
-      <EmbeddedResource Include="Resources\SpritePatches\Environment\DestructibleBlock\DestructibleBlock_DoctorMarioV2.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Environment\DestructibleBlock\DestructibleBlock_SuperMarioBros3.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Environment\DestructibleBlock\DestructibleBlock_SuperMarioBros3V2.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Environment\DestructibleBlock\DestructibleBlock_SuperMarioBros3V3.ips" />
@@ -987,7 +976,6 @@
       <EmbeddedResource Include="Resources\SpritePatches\Environment\StageTiles\AirMan\Block\StageTile_AirMan_Block_Clear.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Environment\StageTiles\AirMan\Block\StageTile_AirMan_Block_Cloud.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Environment\StageTiles\AirMan\Goblin\StageTile_AirMan_Goblin_BabyMetroid.ips" />
-      <EmbeddedResource Include="Resources\SpritePatches\Environment\StageTiles\AirMan\Goblin\StageTile_AirMan_Goblin_CutmanBadScissorsDay.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Environment\StageTiles\AirMan\Goblin\StageTile_AirMan_Goblin_Gamma.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Environment\StageTiles\AirMan\Goblin\StageTile_AirMan_Goblin_Platform.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\Environment\StageTiles\BubbleMan\Block\StageTile_BubbleMan_Block_DiveMan.ips" />
@@ -1128,10 +1116,8 @@
       <EmbeddedResource Include="Resources\SpritePatches\MenusAndTransitionScreens\StageSelectScreen\StageSelectScreen_BasicMaster.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\MenusAndTransitionScreens\StageSelectScreen\StageSelectScreen_Claw.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\MenusAndTransitionScreens\StageSelectScreen\StageSelectScreen_Exile.ips" />
-      <EmbeddedResource Include="Resources\SpritePatches\MenusAndTransitionScreens\StageSelectScreen\StageSelectScreen_FinalMix.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\MenusAndTransitionScreens\StageSelectScreen\StageSelectScreen_None.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\MenusAndTransitionScreens\StageSelectScreen\StageSelectScreen_Ultra.ips" />
-      <EmbeddedResource Include="Resources\SpritePatches\MenusAndTransitionScreens\TitleScreen\TitleScreen_FinalFantasy.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\MenusAndTransitionScreens\WeaponGetScreen\WeaponGetScreen_Claw.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\MenusAndTransitionScreens\WeaponGetScreen\WeaponGetScreen_FinalMix.ips" />
       <EmbeddedResource Include="Resources\SpritePatches\MenusAndTransitionScreens\WeaponGetScreen\WeaponGetScreen_MissingTile.ips" />


### PR DESCRIPTION
Disable graphics that were inadvertently reenabled by #204 