### PR TITLE
Add basic tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet }}
       - run: dotnet build MM2Randomizer.sln
-      - run: dotnet test MM2Randomizer.sln
+      - run: dotnet test MM2Randomizer.sln --configuration Debug
+      - run: dotnet test MM2Randomizer.sln --configuration Release
       - run: dotnet publish --runtime osx-x64 --configuration Release
       - run: dotnet publish --runtime linux-x64 --configuration Release
       - run: dotnet publish --runtime win-x64 --configuration Release

--- a/.github/workflows/release-builds.yml
+++ b/.github/workflows/release-builds.yml
@@ -26,7 +26,8 @@ jobs:
         with:
           dotnet-version: '2.1.x'
       - run: dotnet build MM2Randomizer.sln
-      - run: dotnet test MM2Randomizer.sln
+      - run: dotnet test MM2Randomizer.sln --configuration Debug
+      - run: dotnet test MM2Randomizer.sln --configuration Release
       - run: |
           dotnet publish --runtime osx-x64 --configuration Release -o MegaMan2Randomizer2
           zip -r MegaMan2Randomizer2-osx-64.zip MegaMan2Randomizer2

--- a/MM2Randomizer.sln
+++ b/MM2Randomizer.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30406.217
+# 17
+VisualStudioVersion = 17.11.35327.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MM2RandoLib", "MM2RandoLib\MM2RandoLib.csproj", "{2F96FE8D-29DC-46F3-9D26-FC85DC2225C8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RandomizerHost", "RandomizerHost\RandomizerHost.csproj", "{38EECF7E-6242-4407-9D3B-6B8CAC414C44}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FtRandoLib", "FtRandoLib\FtRandoLib.csproj", "{B2DD3A1D-E34D-4C33-BC89-616FE57DCF7A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MM2RandoLib.Tests", "tests\MM2RandoLib.Tests\MM2RandoLib.Tests.csproj", "{9ACE6FCC-17A0-4B3B-BA37-267526BEAD16}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,6 +43,14 @@ Global
 		{B2DD3A1D-E34D-4C33-BC89-616FE57DCF7A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B2DD3A1D-E34D-4C33-BC89-616FE57DCF7A}.Release|x64.ActiveCfg = Release|Any CPU
 		{B2DD3A1D-E34D-4C33-BC89-616FE57DCF7A}.Release|x64.Build.0 = Release|Any CPU
+		{9ACE6FCC-17A0-4B3B-BA37-267526BEAD16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9ACE6FCC-17A0-4B3B-BA37-267526BEAD16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9ACE6FCC-17A0-4B3B-BA37-267526BEAD16}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9ACE6FCC-17A0-4B3B-BA37-267526BEAD16}.Debug|x64.Build.0 = Debug|Any CPU
+		{9ACE6FCC-17A0-4B3B-BA37-267526BEAD16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9ACE6FCC-17A0-4B3B-BA37-267526BEAD16}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9ACE6FCC-17A0-4B3B-BA37-267526BEAD16}.Release|x64.ActiveCfg = Release|Any CPU
+		{9ACE6FCC-17A0-4B3B-BA37-267526BEAD16}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RandomizerHost/ViewModels/MainWindowViewModel.cs
+++ b/RandomizerHost/ViewModels/MainWindowViewModel.cs
@@ -32,17 +32,6 @@ namespace RandomizerHost.ViewModels
             this.SettingsPresets = new(Settings);
             this.SettingsPreset = this.SettingsPresets.Presets[0];
 
-            // If there are any missing fields in the defined presets, display them here
-            try
-            {
-                this.SettingsPresets.ValidatePresets(Settings.AllOptions);
-            }
-            catch (Exception e)
-            {
-                // There MUST be a better way to do this
-                MessageBox.Show(null, e.ToString(), "Error", MessageBox.MessageBoxButtons.Ok);
-            }
-
             // If the application configuration settings does not have a saved value,
             // try to load the Mega Man 2 rom from the executable path
             if (true == String.IsNullOrEmpty(this.AppConfigurationSettings.RomSourcePath))

--- a/tests/MM2RandoLib.Tests/BasicTests.cs
+++ b/tests/MM2RandoLib.Tests/BasicTests.cs
@@ -1,0 +1,66 @@
+using MM2Randomizer;
+using MM2Randomizer.Settings;
+using System;
+using System.IO;
+
+namespace MM2RandoLib.Tests
+{
+    public class BasicTests
+    {
+        /// <summary>
+        /// Verify that the randomizer can successfully create a ROM. This is necessary because assembly modules will not be compiled until a ROM is created.
+        /// </summary>
+        [Fact]
+        public void CanBuildRom()
+        {
+            var curDir = Directory.GetCurrentDirectory();
+            var tempDir = Directory.CreateTempSubdirectory("mm2r");
+            try
+            {
+                Directory.SetCurrentDirectory(tempDir.FullName);
+
+                RandomizationSettings settings = new();
+                settings.RomSourcePath = "mm2.nes";
+                settings.SeedString = null;
+
+                // Enable as many assembly modules as possible
+                settings.GameplayOptions.MercilessMode.BaseValue = true;
+                settings.GameplayOptions.BurstChaserMode.BaseValue = true;
+                settings.GameplayOptions.FasterCutsceneText.BaseValue = true;
+                settings.QualityOfLifeOptions.DisablePauseLock.BaseValue = true;
+                settings.QualityOfLifeOptions.EnableBirdEggFix.BaseValue = true;
+                settings.QualityOfLifeOptions.DisableFlashingEffects.BaseValue = true;
+
+                File.WriteAllBytes(settings.RomSourcePath, new byte[0x80010]);
+
+                RandomizationContext ctx;
+                RandomMM2.RandomizerCreate(settings, out ctx);
+
+                return;
+            }
+            finally
+            {
+                try
+                {
+                    Directory.SetCurrentDirectory(curDir);
+                    tempDir.Delete(true);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        /// <summary>
+        /// Verify that all settings presets are complete.
+        /// </summary>
+        [Fact]
+        public void ValidatePresets()
+        {
+            RandomizationSettings settings = new();
+            SettingsPresets presets = new(settings);
+
+            presets.ValidatePresets(settings.AllOptions);
+        }
+    }
+}

--- a/tests/MM2RandoLib.Tests/MM2RandoLib.Tests.csproj
+++ b/tests/MM2RandoLib.Tests/MM2RandoLib.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\MM2RandoLib\MM2RandoLib.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Add 2 basic tests to be performed on PRs and releases:
- Ensure the randomizer is able to generate a ROM. This will be important when js65 is added as the assembly files will not be assembled (and thus validated) until ROM generation.
- Move a super-kludgy test that all settings presets are complete to a test, where it should be