### PR TITLE
Fix incorrect weapon letters at pause

### DIFF
--- a/MM2RandoLib/RandomizationContext.cs
+++ b/MM2RandoLib/RandomizationContext.cs
@@ -316,12 +316,6 @@ namespace MM2Randomizer
                     this.RandomStages,
                     gameplayOpts.RandomizeSpecialWeaponReward.Value,
                     this.RandomWeaponGet);
-
-                MiscHacks.FixWeaponLetters(
-                    this.Patch,
-                    this.RandomWeaponGet,
-                    this.RandomStages,
-                    this.RandomInGameText);
             }
 
             // Apply final optional gameplay modifications

--- a/MM2RandoLib/Randomizers/RText.cs
+++ b/MM2RandoLib/Randomizers/RText.cs
@@ -405,28 +405,6 @@ namespace MM2Randomizer.Randomizers
         }
 
 
-
-        public void FixWeaponLetters(Patch in_Patch, Dictionary<EWeaponIndex, EWeaponIndex> in_Permutation)
-        {
-            // Re-order the pause screen letters to match the ordering
-            // of the shuffled weapons
-            //
-            // TODO: This is done so poorly. Need to think about how to achieve
-            // this without the depencendy of on other randomizers
-
-            foreach (EWeaponIndex i in EWeaponIndex.SpecialWeapons)
-            {
-                Byte[] pauseLetterBytes = this.mNewWeaponLetters[i].AsPauseScreenString();
-
-                Int32 wpnLetterAddress = PauseScreenWpnAddress[in_Permutation[i]];
-
-                for (Int32 j = 0; j < pauseLetterBytes.Length; j++)
-                {
-                    in_Patch.Add(wpnLetterAddress + j, pauseLetterBytes[j], $"Pause menu weapon letter GFX for \'{this.mNewWeaponLetters[i]}\', Byte #{j}");
-                }
-            }
-        }
-
         private static Char GetBossWeaknessDamageChar(Int32 dmg)
         {
             Char c;

--- a/MM2RandoLib/Utilities/MiscHacks.cs
+++ b/MM2RandoLib/Utilities/MiscHacks.cs
@@ -255,15 +255,6 @@ namespace MM2Randomizer.Utilities
             }
         }
 
-        // TODO;
-        public static void FixWeaponLetters(Patch Patch, RWeaponGet randomWeaponGet, RStages randomStages, RText rText)
-        {
-            Dictionary<EWeaponIndex, EWeaponIndex> shuffledWeapons = randomWeaponGet
-                .GetShuffleIndexPermutation()
-                .ToDictionary(x => x.Key.ToWeaponIndex(), x => x.Value.ToWeaponIndex());
-            rText.FixWeaponLetters(Patch, shuffledWeapons);
-        }
-
         /// <summary>
         /// Load the IPS for the specified Mega Man player sprite, or null if the specified sprite is the default. Throws FileNotFoundException if the sprite cannot be found (should never happen).
         /// </summary>


### PR DESCRIPTION
Fix a longstanding bug in MM2R that swaps the order of letters shown in the pause menu exactly as the stage associations are swapped. This results in the letters in the pause menu corresponding to the stages they came from, not the weapon the letter belongs to.