### PR TITLE
Add accidental e-tank usage prevention option

### DIFF
--- a/MM2RandoLib/Resources/Asm/Auto/refill_speed.asm
+++ b/MM2RandoLib/Resources/Asm/Auto/refill_speed.asm
@@ -33,8 +33,13 @@
 
 .org $9296
 UseEtank:
+.if ETANK_PROTECTION_LEVEL <> MAX_ENERGY
+	jsr ShouldUseEtank
+.else
 	LDA ObjHitPoints ; Do not proceed if life is full
 	CMP #MAX_ENERGY
+.endif
+
 	BEQ $9274
 
 	DEC NumEtanks
@@ -81,6 +86,25 @@ EtankIncreaseHealth:
 
 +
 	RTS
+
+.endif
+
+.if ETANK_PROTECTION_LEVEL <> MAX_ENERGY
+
+.reloc
+ShouldUseEtank: ; Returns Z if no
+	lda ObjHitPoints
+	cmp #MAX_ENERGY
+	beq @Done ; Z: no
+
+	cmp #ETANK_PROTECTION_LEVEL
+	bcc @Done ; !Z: yes
+
+	lda CtrlState
+	and #$4 ; Select is pressed
+
+@Done:
+	rts
 
 .endif
 

--- a/MM2RandoLib/Resources/Asm/mm2r_base.inc
+++ b/MM2RandoLib/Resources/Asm/mm2r_base.inc
@@ -39,6 +39,7 @@ MIRROR_HORIZONTAL = 1
 ;;;;;;;;;; Global variables and constants
 
 FrameCtr = $1c
+CtrlState = $23
 LevelIdx = $2a
 CurObjIdx = $2b
 IframesLeft = $4b

--- a/MM2RandoLib/Settings/OptionGroups/QualityOfLifeOptions.cs
+++ b/MM2RandoLib/Settings/OptionGroups/QualityOfLifeOptions.cs
@@ -38,6 +38,11 @@ namespace MM2Randomizer.Settings.OptionGroups
         [PatchRom(0x37bea, 1)]
         public BoolOption StageSelectDefault { get; } = new(true);
 
+        [Description("E-Tank Health Threshold")]
+        [Tooltip("Prevents e-tanks from being used at this health and above. To force e-tank use at this level hold Select when Start is pressed.")]
+        [DefineValueSymbol("ETANK_PROTECTION_LEVEL")]
+        public EnumOption<PercentOption> AccidentalEtankProtectionLevel { get; } = new(PercentOption.Percent100);
+
         [Description("Weapons Regained on Death")]
         [Tooltip("Regains this amount of energy for all weapons on death.")]
         [DefineValueSymbol("REGAIN_WEAPON_ENERGY_ON_DEATH")]

--- a/MM2RandoLib/Settings/SettingsPresets.cs
+++ b/MM2RandoLib/Settings/SettingsPresets.cs
@@ -126,6 +126,7 @@ public class SettingsPresets
                 new(s.QualityOfLifeOptions.EnableLeftwardWallEjection, false),
                 new(s.QualityOfLifeOptions.EnableBirdEggFix, true),
                 new(s.QualityOfLifeOptions.StageSelectDefault, false),
+                NewPreset(s.QualityOfLifeOptions.AccidentalEtankProtectionLevel, PercentOption.Percent100),
                 NewPreset(s.QualityOfLifeOptions.AddWeaponEnergyOnDeath, PercentOption.Percent0),
                 new(s.CosmeticOptions.RandomizeColorPalettes, true),
                 new(s.CosmeticOptions.RandomizeMusicTracks, true),


### PR DESCRIPTION
Implements #157

Adds an option for e-tank threshold. If life is at this level or above, select must be held while pressing start to use an e-tank.