### PR TITLE
Add self-destruct

### DIFF
--- a/MM2RandoLib/MM2RandoLib.csproj
+++ b/MM2RandoLib/MM2RandoLib.csproj
@@ -80,6 +80,7 @@
       <None Remove="Resources\Asm\Options\faster_cutscenes.asm" />
       <None Remove="Resources\Asm\Options\merciless.asm" />
       <None Remove="Resources\Asm\Options\pause_with_items.asm" />
+      <None Remove="Resources\Asm\Options\self_destruct.asm" />
       <None Remove="Resources\Asm\prepatch.asm" />
       <None Remove="Resources\Batton_Batman.ips" />
       <None Remove="Resources\EnemySet.xml" />
@@ -724,6 +725,7 @@
       <EmbeddedResource Include="Resources\Asm\Options\faster_cutscenes.asm" />
       <EmbeddedResource Include="Resources\Asm\Options\merciless.asm" />
       <EmbeddedResource Include="Resources\Asm\Options\pause_with_items.asm" />
+      <EmbeddedResource Include="Resources\Asm\Options\self_destruct.asm" />
       <EmbeddedResource Include="Resources\Asm\prepatch.asm" />
       <EmbeddedResource Include="Resources\EnemySet.xml" />
       <EmbeddedResource Include="Resources\EnemyWeaknessSet.xml" />

--- a/MM2RandoLib/Resources/Asm/Options/self_destruct.asm
+++ b/MM2RandoLib/Resources/Asm/Options/self_destruct.asm
@@ -7,7 +7,7 @@
 
 .reloc
 PatchDoPauseScreen:
-	; Okay to clobber A, X, Y?
+	; Okay to clobber A, X (Y??)
 	lda CtrlState
 	eor #$ff
 	and #$11 ; = 0 if Up and A are held

--- a/MM2RandoLib/Resources/Asm/Options/self_destruct.asm
+++ b/MM2RandoLib/Resources/Asm/Options/self_destruct.asm
@@ -1,0 +1,20 @@
+.include "mm2r.inc"
+
+.segment "BANKE"
+
+.org $817e ; Part of main game loop
+	jsr PatchDoPauseScreen ; Was jsr DoPauseScreen
+
+.reloc
+PatchDoPauseScreen:
+	; Okay to clobber A, X, Y?
+	lda CtrlState
+	eor #$ff
+	and #$11 ; = 0 if Up and A are held
+	bne +
+
+	sta MmState ; Explosion only occurs if MmState == 0
+	jmp DoDeath
+
++
+	jmp DoPauseScreen

--- a/MM2RandoLib/Resources/Asm/mm2r_base.inc
+++ b/MM2RandoLib/Resources/Asm/mm2r_base.inc
@@ -42,6 +42,7 @@ FrameCtr = $1c
 CtrlState = $23
 LevelIdx = $2a
 CurObjIdx = $2b
+MmState = $2c
 IframesLeft = $4b
 WpnsAcquiredMask = $9a
 ItemsAcquiredMask = $9b
@@ -88,7 +89,9 @@ DrawTitleLogoSprites = $a60f ; Bank d
 
 WaitForNmiOutOfGame = $c0ab
 EnqueueSound = $c051
+DoDeath = $c10b
 LoadStageTileset = $c45d
+DoPauseScreen = $c573
 SpawnEnemyFromEnemy = $f159
 
 ; Macros

--- a/MM2RandoLib/Settings/OptionGroups/QualityOfLifeOptions.cs
+++ b/MM2RandoLib/Settings/OptionGroups/QualityOfLifeOptions.cs
@@ -38,6 +38,11 @@ namespace MM2Randomizer.Settings.OptionGroups
         [PatchRom(0x37bea, 1)]
         public BoolOption StageSelectDefault { get; } = new(true);
 
+        [Description("Allow Self-Destruct")]
+        [Tooltip("Holding Up and A while pressing Start to pause instantly kills Mega Man. Good for getting out of soft-locks.")]
+        [AssembleFile("Options.self_destruct.asm")]
+        public BoolOption AllowSelfDestruct { get; } = new(true);
+
         [Description("E-Tank Health Threshold")]
         [Tooltip("Prevents e-tanks from being used at this health and above. To force e-tank use at this level hold Select when Start is pressed.")]
         [DefineValueSymbol("ETANK_PROTECTION_LEVEL")]

--- a/MM2RandoLib/Settings/SettingsPresets.cs
+++ b/MM2RandoLib/Settings/SettingsPresets.cs
@@ -126,6 +126,7 @@ public class SettingsPresets
                 new(s.QualityOfLifeOptions.EnableLeftwardWallEjection, false),
                 new(s.QualityOfLifeOptions.EnableBirdEggFix, true),
                 new(s.QualityOfLifeOptions.StageSelectDefault, false),
+                new(s.QualityOfLifeOptions.AllowSelfDestruct, false),
                 NewPreset(s.QualityOfLifeOptions.AccidentalEtankProtectionLevel, PercentOption.Percent100),
                 NewPreset(s.QualityOfLifeOptions.AddWeaponEnergyOnDeath, PercentOption.Percent0),
                 new(s.CosmeticOptions.RandomizeColorPalettes, true),


### PR DESCRIPTION
Add option to allow self-destruct when up, A, and start are pressed.

Satisfies #20 as a means of preventing soft-locks.