### PR TITLE
Implement fair Heat Man option

### DIFF
--- a/MM2RandoLib/MM2RandoLib.csproj
+++ b/MM2RandoLib/MM2RandoLib.csproj
@@ -78,6 +78,7 @@
       <None Remove="Resources\Asm\Options\bird_egg_fix.asm" />
       <None Remove="Resources\Asm\Options\burst_chaser.asm" />
       <None Remove="Resources\Asm\Options\disable_flashing.asm" />
+      <None Remove="Resources\Asm\Options\fair_heat_man.asm" />
       <None Remove="Resources\Asm\Options\faster_cutscenes.asm" />
       <None Remove="Resources\Asm\Options\merciless.asm" />
       <None Remove="Resources\Asm\Options\pause_with_items.asm" />
@@ -739,6 +740,7 @@
       <EmbeddedResource Include="Resources\Asm\Options\bird_egg_fix.asm" />
       <EmbeddedResource Include="Resources\Asm\Options\burst_chaser.asm" />
       <EmbeddedResource Include="Resources\Asm\Options\disable_flashing.asm" />
+      <EmbeddedResource Include="Resources\Asm\Options\fair_heat_man.asm" />
       <EmbeddedResource Include="Resources\Asm\Options\faster_cutscenes.asm" />
       <EmbeddedResource Include="Resources\Asm\Options\merciless.asm" />
       <EmbeddedResource Include="Resources\Asm\Options\pause_with_items.asm" />

--- a/MM2RandoLib/RandomizationContext.cs
+++ b/MM2RandoLib/RandomizationContext.cs
@@ -253,6 +253,11 @@ namespace MM2Randomizer
                     "CheatMode", StringComparison.InvariantCultureIgnoreCase);
             }
 
+            // Generate a seed for fair Heat Man
+            if (gameplayOpts.FairHeatManDelays.Value)
+                DefineSymbolLines.Add(
+                    $".define FAIR_HEAT_MAN_SEED ${Seed.NextUInt8(1, 256):x}");
+
             // Conduct randomization of behavior options
             foreach (IRandomizer randomizer in randomizers)
             {

--- a/MM2RandoLib/Resources/Asm/Options/fair_heat_man.asm
+++ b/MM2RandoLib/Resources/Asm/Options/fair_heat_man.asm
@@ -1,0 +1,67 @@
+﻿.include "mm2r.inc"
+
+LfsrState = BossVar3
+
+.segment "BANKB"
+
+.org $80d3
+	; Boss' life meter has fully filled
+	; 80D3  AD E1 04       LDA $04E1
+
+	jsr SetHeatManMode2
+
+	FREE_UNTIL $80d6
+
+
+.org $82ac
+	; $d bytes
+	; 82AC  A5 4A          LDA $4A ; Random number
+	; 82AE  85 01          STA $01
+	; 82B0  A9 03          LDA #$03 ; Divide by 3
+	; 82B2  85 02          STA $02
+	; 82B4  20 4E C8       JSR $C84E
+	; 82B7  A6 04          LDX $04
+
+	; 8 bytes
+	lda LfsrState
+	lsr a
+	bcc +
+
+	eor #$b8
+
++
+	; 5 bytes
+	jsr GetHeatManDelayCont
+	tax
+	nop
+
+	FREE_UNTIL $82b9
+
+
+.reloc
+
+SetHeatManMode2:
+	lda #FAIR_HEAT_MAN_SEED
+	sta LfsrState
+
+	lda GenObjVars + 1
+
+	rts
+
+GetHeatManDelayCont:
+	sta LfsrState
+
+	eor #%10010010
+
+	cmp #($100 * 2 / 3)
+	bcs +
+
+	cmp #($100 / 3)
+	lda #$0
+	rol a
+	
+	rts
+
++
+	lda #$2
+	rts

--- a/MM2RandoLib/Resources/Asm/Options/fair_heat_man.asm
+++ b/MM2RandoLib/Resources/Asm/Options/fair_heat_man.asm
@@ -8,7 +8,7 @@ LfsrState = BossVar3
 	; Boss' life meter has fully filled
 	; 80D3  AD E1 04       LDA $04E1
 
-	jsr SetHeatManMode2
+	jsr InitHeatMan
 
 	FREE_UNTIL $80d6
 
@@ -40,7 +40,7 @@ LfsrState = BossVar3
 
 .reloc
 
-SetHeatManMode2:
+InitHeatMan:
 	lda #FAIR_HEAT_MAN_SEED
 	sta LfsrState
 

--- a/MM2RandoLib/Resources/Asm/mm2r_base.inc
+++ b/MM2RandoLib/Resources/Asm/mm2r_base.inc
@@ -60,6 +60,11 @@ ObjAnimVars = $680
 ObjFrameCtrs = $6a0
 ObjHitPoints = $6c0
 
+BossBehavior = $b1
+BossVar = $b2
+BossVar2 = $b4
+BossVar3 = $5ab
+
 NUM_ITEMS = $b
 MAX_ENERGY = $1c
 

--- a/MM2RandoLib/Settings/OptionGroups/GameplayOptions.cs
+++ b/MM2RandoLib/Settings/OptionGroups/GameplayOptions.cs
@@ -63,5 +63,10 @@ namespace MM2Randomizer.Settings.OptionGroups
         [Description("Disallow Bubble Barrier Vulnerability")]
         [Tooltip("Do not allow Bubble Lead to be the vulnerability of Crash barriers to avoid strange interactions especially during Boobeam fight.")]
         public BoolOption DisallowBubbleBarrierWeakness { get; } = new(true);
+
+        [Description("Deterministic Heat Man Delays")]
+        [Tooltip("Randomize Heat Man delays at seed generation, repeating the same pattern every life to ensure the same pattern occurs for all players.")]
+        [AssembleFile("Options.fair_heat_man.asm")]
+        public BoolOption FairHeatManDelays { get; } = new(false);
     }
 }

--- a/MM2RandoLib/Settings/SettingsPresets.cs
+++ b/MM2RandoLib/Settings/SettingsPresets.cs
@@ -110,6 +110,7 @@ public class SettingsPresets
                 new(s.GameplayOptions.MercilessMode, false),
                 new(s.GameplayOptions.RandomizePicoPicoSpawns, true),
                 new(s.GameplayOptions.DisallowBubbleBarrierWeakness, true),
+                new(s.GameplayOptions.FairHeatManDelays, false),
                 new(s.SpriteOptions.RandomizeBossSprites, true),
                 new(s.SpriteOptions.RandomizeEnemySprites, true),
                 new(s.SpriteOptions.RandomizeSpecialWeaponSprites, true),


### PR DESCRIPTION
Use a simple LFSR RNG to determine which Heat Man delay to use. This RNG is seeded with a constant selected during randomization every attempt at Heat Man.