### PR TITLE
Remove heavy sound effects from item shuffle

### DIFF
--- a/MM2RandoLib/Enums/ESoundID.cs
+++ b/MM2RandoLib/Enums/ESoundID.cs
@@ -3,7 +3,7 @@
     public enum ESoundID
     {
         WeaponF         = 0x21,
-        HeatmanUnused   = 0x22,
+        HeatmanUnused   = 0x22, // no
         WeaponM         = 0x23,
         WeaponP         = 0x24,
         Shotman         = 0x25,
@@ -16,25 +16,25 @@
         Dragon          = 0x2C, 
         Tink            = 0x2D, 
         CrashAttach     = 0x2E,
-        Cursor          = 0x2F, 
-        TeleportIn      = 0x30,
+        Cursor          = 0x2F,
+        Unpause         = 0x30,
         WeaponW         = 0x31, 
         Pause           = 0x32,    
-        Unknown0        = 0x33, // no
+        Unknown0        = 0x33,
         BossDoor        = 0x34, // no
         WeaponH_Charge0 = 0x35, // yes, but randomize the 3
         WeaponH_Charge1 = 0x36,
         WeaponH_Charge2 = 0x37,
         WeaponH_Shoot   = 0x38,
         FlyBoy          = 0x39,
-        TeleportOut     = 0x3A,
+        TeleportOut     = 0x3A, // no
         Splash          = 0x3B,
         Yoku            = 0x3C,
         Droplet1        = 0x3D,
         Droplet2        = 0x3E, // no
         WeaponA         = 0x3F,
         Unknown1        = 0x40, // yes. weird fuzz sound?
-        Death           = 0x41,
+        Death           = 0x41, // no
         OneUp           = 0x42,
     }
 }

--- a/MM2RandoLib/Enums/ESoundID.cs
+++ b/MM2RandoLib/Enums/ESoundID.cs
@@ -3,7 +3,7 @@
     public enum ESoundID
     {
         WeaponF         = 0x21,
-        HeatmanUnused   = 0x22, // no
+        HeatmanUnused   = 0x22, // No. Uses all channels.
         WeaponM         = 0x23,
         WeaponP         = 0x24,
         Shotman         = 0x25,
@@ -11,7 +11,7 @@
         QuickBeam       = 0x27,
         Refill          = 0x28, 
         MegaLand        = 0x29,  
-        WilyDefeat      = 0x2A, // no
+        WilyDefeat      = 0x2A, // No. Too long for SFX.
         DamageEnemy     = 0x2B, 
         Dragon          = 0x2C, 
         Tink            = 0x2D, 
@@ -21,20 +21,20 @@
         WeaponW         = 0x31, 
         Pause           = 0x32,    
         Unknown0        = 0x33,
-        BossDoor        = 0x34, // no
-        WeaponH_Charge0 = 0x35, // yes, but randomize the 3
+        BossDoor        = 0x34, // No. Uses music square.
+        WeaponH_Charge0 = 0x35, // Yes, but randomize the 3
         WeaponH_Charge1 = 0x36,
         WeaponH_Charge2 = 0x37,
         WeaponH_Shoot   = 0x38,
         FlyBoy          = 0x39,
-        TeleportOut     = 0x3A, // no
+        TeleportOut     = 0x3A, // No. Uses music square.
         Splash          = 0x3B,
         Yoku            = 0x3C,
         Droplet1        = 0x3D,
-        Droplet2        = 0x3E, // no
+        Droplet2        = 0x3E, // No. Uses music square.
         WeaponA         = 0x3F,
-        Unknown1        = 0x40, // yes. weird fuzz sound?
-        Death           = 0x41, // no
+        Unknown1        = 0x40, // Yes. Weird fuzz sound?
+        Death           = 0x41, // No. Uses music square.
         OneUp           = 0x42,
     }
 }

--- a/MM2RandoLib/Enums/ESoundID.cs
+++ b/MM2RandoLib/Enums/ESoundID.cs
@@ -17,7 +17,7 @@
         Tink            = 0x2D, 
         CrashAttach     = 0x2E,
         Cursor          = 0x2F,
-        Unpause         = 0x30,
+        TeleportIn      = 0x30,
         WeaponW         = 0x31, 
         Pause           = 0x32,    
         Unknown0        = 0x33,

--- a/MM2RandoLib/Randomizers/RWeaponBehavior.cs
+++ b/MM2RandoLib/Randomizers/RWeaponBehavior.cs
@@ -46,6 +46,7 @@ namespace MM2Randomizer.Randomizers
 
         private static List<ESoundID> GetSoundList()
         {
+            // See ESoundID for explanations of omitted SFX
             return new List<ESoundID>(new ESoundID[] {
                 ESoundID.WeaponF,
                 ESoundID.WeaponM,

--- a/MM2RandoLib/Randomizers/RWeaponBehavior.cs
+++ b/MM2RandoLib/Randomizers/RWeaponBehavior.cs
@@ -60,7 +60,7 @@ namespace MM2Randomizer.Randomizers
                 ESoundID.Tink,
                 ESoundID.CrashAttach,
                 ESoundID.Cursor,
-                ESoundID.Unpause,
+                ESoundID.TeleportIn,
                 ESoundID.WeaponW,
                 ESoundID.Pause,
                 ESoundID.Unknown0,

--- a/MM2RandoLib/Randomizers/RWeaponBehavior.cs
+++ b/MM2RandoLib/Randomizers/RWeaponBehavior.cs
@@ -48,7 +48,6 @@ namespace MM2Randomizer.Randomizers
         {
             return new List<ESoundID>(new ESoundID[] {
                 ESoundID.WeaponF,
-                ESoundID.HeatmanUnused,
                 ESoundID.WeaponM,
                 ESoundID.WeaponP,
                 ESoundID.Shotman,
@@ -61,19 +60,18 @@ namespace MM2Randomizer.Randomizers
                 ESoundID.Tink,
                 ESoundID.CrashAttach,
                 ESoundID.Cursor,
-                ESoundID.TeleportIn,
+                ESoundID.Unpause,
                 ESoundID.WeaponW,
                 ESoundID.Pause,
+                ESoundID.Unknown0,
                 ESoundID.WeaponH_Charge0,
                 ESoundID.WeaponH_Shoot,
                 ESoundID.FlyBoy,
-                ESoundID.TeleportOut,
                 ESoundID.Splash,
                 ESoundID.Yoku,
                 ESoundID.Droplet1,
                 ESoundID.WeaponA,
                 ESoundID.Unknown1,
-                ESoundID.Death,
                 ESoundID.OneUp,
             });
         }

--- a/MM2RandoLib/Resources/Asm/Auto/misc_hacks.asm
+++ b/MM2RandoLib/Resources/Asm/Auto/misc_hacks.asm
@@ -22,6 +22,14 @@
 	; Stop palette change on kill/despawn
 	NO_OP 3 ; Was jsr $f159
 
+.org $bc35
+
+EnemySfxTable:
+
+; There are two acid drippers ($72 and $73), with two sound effects. $3e uses square 1, $3d uses square 2. Get rid of $3e as it interferes with the music.
+.org $bc35 + $73
+	.byte $3d ; Was $3e
+	
 .segment "BANKF"
 
 ; Preserve e-tanks on game over

--- a/MM2RandoLib/Resources/Asm/Auto/misc_hacks.asm
+++ b/MM2RandoLib/Resources/Asm/Auto/misc_hacks.asm
@@ -22,13 +22,10 @@
 	; Stop palette change on kill/despawn
 	NO_OP 3 ; Was jsr $f159
 
-.org $bc35
-
-EnemySfxTable:
-
 ; There are two acid drippers ($72 and $73), with two sound effects. $3e uses square 1, $3d uses square 2. Get rid of $3e as it interferes with the music.
-.org $bc35 + $73
-	.byte $3d ; Was $3e
+.org $bca7
+DripperSfxTable:
+	.byte $3d, $3d ; Was $3d, $3e
 	
 .segment "BANKF"
 


### PR DESCRIPTION
This PR removes sound effects that interrupt the music (e.g. death) from the set that can be selected for weapon effects, as per #221 