### PR TITLE
add random ice stage logic

### DIFF
--- a/MM2RandoLib/MM2RandoLib.csproj
+++ b/MM2RandoLib/MM2RandoLib.csproj
@@ -80,6 +80,7 @@
       <None Remove="Resources\Asm\Options\disable_flashing.asm" />
       <None Remove="Resources\Asm\Options\fair_heat_man.asm" />
       <None Remove="Resources\Asm\Options\faster_cutscenes.asm" />
+      <None Remove="Resources\Asm\Options\ice_stage.asm" />
       <None Remove="Resources\Asm\Options\merciless.asm" />
       <None Remove="Resources\Asm\Options\pause_with_items.asm" />
       <None Remove="Resources\Asm\Options\self_destruct.asm" />
@@ -742,6 +743,7 @@
       <EmbeddedResource Include="Resources\Asm\Options\disable_flashing.asm" />
       <EmbeddedResource Include="Resources\Asm\Options\fair_heat_man.asm" />
       <EmbeddedResource Include="Resources\Asm\Options\faster_cutscenes.asm" />
+      <EmbeddedResource Include="Resources\Asm\Options\ice_stage.asm" />
       <EmbeddedResource Include="Resources\Asm\Options\merciless.asm" />
       <EmbeddedResource Include="Resources\Asm\Options\pause_with_items.asm" />
       <EmbeddedResource Include="Resources\Asm\Options\self_destruct.asm" />

--- a/MM2RandoLib/Randomizers/Stages/RStages.cs
+++ b/MM2RandoLib/Randomizers/Stages/RStages.cs
@@ -202,7 +202,7 @@ namespace MM2Randomizer.Randomizers.Stages
             {
                 int iceStage = in_Context.Seed.NextUInt8(8);
                 in_Context.DefineSymbolLines.Add($".define ICE_STAGE ${iceStage}");
-                debug.AppendLine($"\nSelected ice stage: {EBossIndex.All[iceStage]}");
+                debug.AppendLine($"\nSelected ice stage: {EBossIndex.All[iceStage].Name}");
             }
         }
     }

--- a/MM2RandoLib/Randomizers/Stages/RStages.cs
+++ b/MM2RandoLib/Randomizers/Stages/RStages.cs
@@ -197,6 +197,13 @@ namespace MM2Randomizer.Randomizers.Stages
             {
                 in_Patch.Add((Int32)stage.PortraitAddress, (Byte)stage.PortraitDestination.New, $"Stage Select {stage.PortraitName} Destination");
             }
+
+            if (in_Context.Settings.GameplayOptions.RandomizeIceStage.Value)
+            {
+                int iceStage = in_Context.Seed.NextUInt8(8);
+                in_Context.DefineSymbolLines.Add($".define ICE_STAGE ${iceStage}");
+                debug.AppendLine($"\nSelected ice stage: {iceStage}");
+            }
         }
     }
 

--- a/MM2RandoLib/Randomizers/Stages/RStages.cs
+++ b/MM2RandoLib/Randomizers/Stages/RStages.cs
@@ -202,7 +202,7 @@ namespace MM2Randomizer.Randomizers.Stages
             {
                 int iceStage = in_Context.Seed.NextUInt8(8);
                 in_Context.DefineSymbolLines.Add($".define ICE_STAGE ${iceStage}");
-                debug.AppendLine($"\nSelected ice stage: {iceStage}");
+                debug.AppendLine($"\nSelected ice stage: {EBossIndex.All[iceStage]}");
             }
         }
     }

--- a/MM2RandoLib/Resources/Asm/Options/ice_stage.asm
+++ b/MM2RandoLib/Resources/Asm/Options/ice_stage.asm
@@ -1,0 +1,45 @@
+; Pick a random stage to have ice physics.
+; Two things need to be done to make this work:
+;   1. Replace Flash Man's special tile #3 with ground
+;   2. Patch the BG collision check routine to return tile type 7 if it wanted to return tile type 1
+
+.include "mm2r.inc"
+
+.segment "BANKF"
+
+; Very end of bg_collision_check routine
+; Was:
+;   LDA #$E
+;   JSR $C000
+;   RTS
+.org $CC41
+  JSR ice_stage_patch
+  JMP $C000 ; aka Switch16kBank
+
+; Overwrite Flash Man's special tile #3 to ground
+.org $CC52
+  .byte $01
+
+.reloc
+ice_stage_patch:
+  LDA LevelIdx
+  CMP #ICE_STAGE
+  BNE @exit
+  
+  ; Enemies seem to do fine if the ground is ice, but this should help if you run into issues:
+  ; Only override for Mega Man. CurObjIdx isn't actually 00, but underflown to FF for him.
+  ; LDA CurObjIdx
+  ; BPL @exit
+
+  ; $00 contains the actual tile type (not just "special tile #2")
+  LDA $00
+  CMP #1
+  BNE @exit
+  
+  LDA #7
+  STA $00
+
+@exit:
+  ; We are responsible for switching back to bank E on the way out.
+  LDA #$E
+  RTS

--- a/MM2RandoLib/Resources/Asm/Options/ice_stage.asm
+++ b/MM2RandoLib/Resources/Asm/Options/ice_stage.asm
@@ -7,43 +7,43 @@
 
 .segment "BANKF"
 
-; Very end of bg_collision_check routine
+; Very end of BG collision check routine
 ; Was:
-;   LDA #$E
-;   JSR $C000
-;   RTS
-.org $CC41
-  JSR ice_stage_patch
-  JMP $C000 ; aka Switch16kBank
+;   lda #$e
+;   jsr $c000
+;   rts
+.org $cc41
+  jsr IceStagePatch
+  jmp $c000 ; aka Switch16kBank
 
-FREE_UNTIL $CC47
+FREE_UNTIL $cc47
 
 ; Overwrite Flash Man's special tile #3 to ground
-.org $CC52
+.org $cc52
   .byte $01
 
-FREE_UNTIL $CC53
+FREE_UNTIL $cc53
 
 .reloc
-ice_stage_patch:
-  LDA LevelIdx
-  CMP #ICE_STAGE
-  BNE @exit
+IceStagePatch:
+  lda LevelIdx
+  cmp #ICE_STAGE
+  bne @exit
   
   ; Enemies seem to do fine if the ground is ice, but this should help if you run into issues:
-  ; Only override for Mega Man. CurObjIdx isn't actually 00, but underflown to FF for him.
-  ; LDA CurObjIdx
-  ; BPL @exit
+  ; Only override for Mega Man. CurObjIdx isn't actually 00, but underflown to ff for him.
+  ; lda CurObjIdx
+  ; bpl @exit
 
   ; $00 contains the actual tile type (not just "special tile #2")
-  LDA $00
-  CMP #1
-  BNE @exit
+  lda $00
+  cmp #1
+  bne @exit
   
-  LDA #7
-  STA $00
+  lda #7
+  sta $00
 
 @exit:
-  ; We are responsible for switching back to bank E on the way out.
-  LDA #$E
-  RTS
+  ; We are responsible for switching back to bank e on the way out.
+  lda #$e
+  rts

--- a/MM2RandoLib/Resources/Asm/Options/ice_stage.asm
+++ b/MM2RandoLib/Resources/Asm/Options/ice_stage.asm
@@ -16,9 +16,13 @@
   JSR ice_stage_patch
   JMP $C000 ; aka Switch16kBank
 
+FREE_UNTIL $CC47
+
 ; Overwrite Flash Man's special tile #3 to ground
 .org $CC52
   .byte $01
+
+FREE_UNTIL $CC53
 
 .reloc
 ice_stage_patch:

--- a/MM2RandoLib/Settings/OptionGroups/GameplayOptions.cs
+++ b/MM2RandoLib/Settings/OptionGroups/GameplayOptions.cs
@@ -59,7 +59,6 @@ namespace MM2Randomizer.Settings.OptionGroups
         [Description("Randomize PicoPico-kun Spawns")]
         public BoolOption RandomizePicoPicoSpawns { get; } = new(true);
 
-
         [Description("Disallow Bubble Barrier Vulnerability")]
         [Tooltip("Do not allow Bubble Lead to be the vulnerability of Crash barriers to avoid strange interactions especially during Boobeam fight.")]
         public BoolOption DisallowBubbleBarrierWeakness { get; } = new(true);
@@ -68,5 +67,10 @@ namespace MM2Randomizer.Settings.OptionGroups
         [Tooltip("Randomize Heat Man delays at seed generation, repeating the same pattern every life to ensure the same pattern occurs for all players.")]
         [AssembleFile("Options.fair_heat_man.asm")]
         public BoolOption FairHeatManDelays { get; } = new(false);
+
+        [Description("Randomize Ice Stage")]
+        [Tooltip("Pick a random stage to have ice physics.")]
+        [AssembleFile("Options.ice_stage.asm")]
+        public BoolOption RandomizeIceStage { get; } = new(true);
     }
 }

--- a/MM2RandoLib/Settings/SettingsPresets.cs
+++ b/MM2RandoLib/Settings/SettingsPresets.cs
@@ -111,6 +111,7 @@ public class SettingsPresets
                 new(s.GameplayOptions.RandomizePicoPicoSpawns, true),
                 new(s.GameplayOptions.DisallowBubbleBarrierWeakness, true),
                 new(s.GameplayOptions.FairHeatManDelays, false),
+                new(s.GameplayOptions.RandomizeIceStage, true),
                 new(s.SpriteOptions.RandomizeBossSprites, true),
                 new(s.SpriteOptions.RandomizeEnemySprites, true),
                 new(s.SpriteOptions.RandomizeSpecialWeaponSprites, true),


### PR DESCRIPTION
https://github.com/squid-man/MegaMan2Randomizer2/issues/19

Adding some asm that makes the ground in a specific stage into ice.

Questions:
- Do I need to use that FREE_UNTIL macro? I didn't, but everything seems to work just fine. I don't really know what it does.
- Should I also include the Wily stages as valid targets?
  - Why does `EStageID` only go up to 7, even though Wily 1-6 really are stages 8 - D?