### PR TITLE
Fix janky Quick Man laser sprites

### DIFF
--- a/MM2RandoLib/Randomizers/Colors/RColors.cs
+++ b/MM2RandoLib/Randomizers/Colors/RColors.cs
@@ -2102,25 +2102,24 @@ namespace MM2Randomizer.Randomizers.Colors
                 },
 
                 new ColorSet() { // Quick | Beams and Background
-                    addresses = new Int32[] {0x013e17, 0x013e18, 0x013e19, 0x013e1b, 0x013e1c, 0x013e1d},
-                    ColorBytes = new List<EColorsHex[]>() {
+                    addresses = new Int32[] {0x013e17, 0x013e18, 0x013e19, 0x134b5, 0x134b6, 0x134b7, 0x013e1b, 0x013e1c, 0x013e1d},
+                    ColorBytes = new List<EColorsHex[]>() { // Need extra copies of the beam colors to make the BG tiles and sprites match
                         // Default
-                        new EColorsHex[] {(EColorsHex)0x37,(EColorsHex)0x27,(EColorsHex)0x07,(EColorsHex)0x28,(EColorsHex)0x16,(EColorsHex)0x07, },
+                        new EColorsHex[] {(EColorsHex)0x37,(EColorsHex)0x27,(EColorsHex)0x07,(EColorsHex)0x37,(EColorsHex)0x27,(EColorsHex)0x07,(EColorsHex)0x28,(EColorsHex)0x16,(EColorsHex)0x07, },
                         // Purple
-                        new EColorsHex[] {(EColorsHex)0x34,(EColorsHex)0x24,(EColorsHex)0x04,(EColorsHex)0x25,(EColorsHex)0x13,(EColorsHex)0x04, },
+                        new EColorsHex[] {(EColorsHex)0x34,(EColorsHex)0x24,(EColorsHex)0x04,(EColorsHex)0x34,(EColorsHex)0x24,(EColorsHex)0x04,(EColorsHex)0x25,(EColorsHex)0x13,(EColorsHex)0x04, },
                         // Blue
-                        new EColorsHex[] {(EColorsHex)0x32,(EColorsHex)0x22,(EColorsHex)0x02,(EColorsHex)0x23,(EColorsHex)0x11,(EColorsHex)0x02, },
+                        new EColorsHex[] {(EColorsHex)0x32,(EColorsHex)0x22,(EColorsHex)0x02,(EColorsHex)0x32,(EColorsHex)0x22,(EColorsHex)0x02,(EColorsHex)0x23,(EColorsHex)0x11,(EColorsHex)0x02, },
                         // Cyan
-                        new EColorsHex[] {(EColorsHex)0x3C,(EColorsHex)0x2C,(EColorsHex)0x0C,(EColorsHex)0x21,(EColorsHex)0x1B,(EColorsHex)0x0C, },
+                        new EColorsHex[] {(EColorsHex)0x3C,(EColorsHex)0x2C,(EColorsHex)0x0C,(EColorsHex)0x3C,(EColorsHex)0x2C,(EColorsHex)0x0C,(EColorsHex)0x21,(EColorsHex)0x1B,(EColorsHex)0x0C, },
                         // Green
-                        new EColorsHex[] {(EColorsHex)0x3a,(EColorsHex)0x2a,(EColorsHex)0x0a,(EColorsHex)0x2b,(EColorsHex)0x19,(EColorsHex)0x0a, },
+                        new EColorsHex[] {(EColorsHex)0x3a,(EColorsHex)0x2a,(EColorsHex)0x0a,(EColorsHex)0x3a,(EColorsHex)0x2a,(EColorsHex)0x0a,(EColorsHex)0x2b,(EColorsHex)0x19,(EColorsHex)0x0a, },
                         // Green 2
-                        new EColorsHex[] {(EColorsHex)0x39,(EColorsHex)0x29,(EColorsHex)0x09,(EColorsHex)0x2a,(EColorsHex)0x18,(EColorsHex)0x09, },
+                        new EColorsHex[] {(EColorsHex)0x39,(EColorsHex)0x29,(EColorsHex)0x09,(EColorsHex)0x39,(EColorsHex)0x29,(EColorsHex)0x09,(EColorsHex)0x2a,(EColorsHex)0x18,(EColorsHex)0x09, },
                         // Gold
-                        new EColorsHex[] {(EColorsHex)0x38,(EColorsHex)0x28,(EColorsHex)0x08,(EColorsHex)0x29,(EColorsHex)0x17,(EColorsHex)0x08, },
+                        new EColorsHex[] {(EColorsHex)0x38,(EColorsHex)0x28,(EColorsHex)0x08,(EColorsHex)0x38,(EColorsHex)0x28,(EColorsHex)0x08,(EColorsHex)0x29,(EColorsHex)0x17,(EColorsHex)0x08, },
                         // Gray
-                        new EColorsHex[] {(EColorsHex)0x0f,(EColorsHex)0x0f,(EColorsHex)0x00,(EColorsHex)0x20,(EColorsHex)0x10,(EColorsHex)0x00, },
-
+                        new EColorsHex[] {(EColorsHex)0x0f,(EColorsHex)0x0f,(EColorsHex)0x00,(EColorsHex)0x0f,(EColorsHex)0x0f,(EColorsHex)0x00,(EColorsHex)0x20,(EColorsHex)0x10,(EColorsHex)0x00, },
                     }
                 },
 

--- a/MM2RandoLib/Randomizers/Enemies/REnemies.cs
+++ b/MM2RandoLib/Randomizers/Enemies/REnemies.cs
@@ -485,7 +485,8 @@ namespace MM2Randomizer.Randomizers.Enemies
             // Quick Bank 0 - Used in empty room only
             RoomGroups.Add(new SpriteBankRoomGroup(EStageID.QuickW5, 0x013482, new Int32[] { 7 })); // Bank 1
             RoomGroups.Add(new SpriteBankRoomGroup(EStageID.QuickW5, 0x013494, new Int32[] { 15 })); // Bank 2
-            RoomGroups.Add(new SpriteBankRoomGroup(EStageID.QuickW5, 0x0134A6, new Int32[] { 3, 4, 5, 8, 9, 10, 11, 12, 13, 14 })); // Bank 3
+            RoomGroups.Add(new SpriteBankRoomGroup(EStageID.QuickW5, 0x0134A6, new Int32[] { 3, 4, 5, 8, 9, 10, 11, 12, 13, 14 }, // Bank 3
+                new Int32[] { 3 }, new Byte[] { 0x94, 0x02 })); // Laser sprite
             // Quick Bank 4 - Quick fight // 0x0134B8
             RoomGroups.Add(new SpriteBankRoomGroup(EStageID.QuickW5, 0x0134CA, new Int32[] { 1, 2 })); // Bank 5
             // Quick Bank 6 - W5 Teleporters
@@ -810,7 +811,7 @@ namespace MM2Randomizer.Randomizers.Enemies
                     // (i.e. certain rooms must use certain rows on the sprite table to draw mandatory objects or effects
                     if (sbrg.IsSpriteRestricted)
                     {
-                        // Check if this enemy uses the restricted row in the sprite bank
+                        // Check if this enemy uses a restricted row in the sprite bank
                         List<Int32> commonRows = en.SpriteBankRows.Intersect(sbrg.SpriteBankRowsRestriction).ToList();
                         if (commonRows.Count != 0)
                         {

--- a/MM2RandoLib/Randomizers/Enemies/REnemies.cs
+++ b/MM2RandoLib/Randomizers/Enemies/REnemies.cs
@@ -458,7 +458,8 @@ namespace MM2Randomizer.Randomizers.Enemies
 
             // Woodman & Wily 3 stage enemies
             // NOTE: Access to sprite banks 0-7, plus extra banks 0x90 and 0xA2
-            RoomGroups.Add(new SpriteBankRoomGroup(EStageID.WoodW3, 0x00b470, new Int32[] { 10, 22 })); // Bank 0; Moved Room 10 from bank 3
+            RoomGroups.Add(new SpriteBankRoomGroup(EStageID.WoodW3, 0x00b470, new Int32[] { 10, 22 }, // Bank 0; Moved Room 10 from bank 3
+                new Int32[] { 4 }, new byte[] { 0x9F, 0x04 })); // Splishy splash sprite. This one's not as important because it's at the very end of Wily 3, where you would only encounter it when jumping back into the water.
             RoomGroups.Add(new SpriteBankRoomGroup(EStageID.WoodW3, 0x00B482, new Int32[] { 1, 6 })); // Bank 1
             RoomGroups.Add(new SpriteBankRoomGroup(EStageID.WoodW3, 0x00B494, new Int32[] { 7 })); // Bank 2
             RoomGroups.Add(new SpriteBankRoomGroup(EStageID.WoodW3, 0x00B4A6, new Int32[] { 0 })); // Bank 3
@@ -466,15 +467,17 @@ namespace MM2Randomizer.Randomizers.Enemies
             // Rooms.Add(new EnemyRoom(EStageID.WoodW3, 0x00B4CA, new Int32[] { 2, 3, 4 })); // Bank 5 - Friender rooms
             // Wood Bank 6 - Wood fight 0x00B4DC
             // Wood Bank 7 - Gutsdozer fight
-            RoomGroups.Add(new SpriteBankRoomGroup(EStageID.WoodW3, 0x00b500, new Int32[] { 8, 16 })); // Bank ? (0x90); Moved Room 8 from bank 3
-            RoomGroups.Add(new SpriteBankRoomGroup(EStageID.WoodW3, 0x00b512, new Int32[] { 9, 17 })); // Bank ? (0xA2); Moved Room 9 from bank 3
+            RoomGroups.Add(new SpriteBankRoomGroup(EStageID.WoodW3, 0x00b500, new Int32[] { 8, 16 })); // Bank 8 (0x90); Moved Room 8 from bank 3
+            RoomGroups.Add(new SpriteBankRoomGroup(EStageID.WoodW3, 0x00b512, new Int32[] { 9, 17 }, // Bank 9 (0xA2); Moved Room 9 from bank 3
+                new Int32[] { 4 }, new byte[] { 0x9F, 0x04 })); // Splishy splash sprite
 
             // Bubbleman & Wily 4 stage enemies
             RoomGroups.Add(new SpriteBankRoomGroup(EStageID.BubbleW4, 0x00F470, new Int32[] { 0, 5 }, // Bank 0
-                new Int32[] { 2 }, new Byte[] { 0x9D, 0x02 })); // Falling platform sprite
-            RoomGroups.Add(new SpriteBankRoomGroup(EStageID.BubbleW4, 0x00F482, new Int32[] { 1, 2, 3 })); // Bank 1
+                new Int32[] { 2, 4 }, new Byte[] { 0x9D, 0x02, 0x9F, 0x04 })); // Falling platform & splishy splash sprites
+            RoomGroups.Add(new SpriteBankRoomGroup(EStageID.BubbleW4, 0x00F482, new Int32[] { 1, 2, 3 }, // Bank 1
+                new Int32[] { 4 }, new byte[] { 0x9F, 0x04 })); // Splishy splash sprite
             RoomGroups.Add(new SpriteBankRoomGroup(EStageID.BubbleW4, 0x00F494, new Int32[] { 4 }, // Bank 2
-                new Int32[] { 0, 1 }, new Byte[] { 0x9E, 0x02, 0x9F, 0x02 })); // Shrimp sprites
+                new Int32[] { 0, 1 }, new Byte[] { 0x9E, 0x02, 0x9F, 0x02 })); // Shrimp sprites. TODO: Is this one actually necessary anymore? Seems the anko minibosses are removed.
             // Bubble Bank 3 - Bubbleman fight 0x00F4A6
             RoomGroups.Add(new SpriteBankRoomGroup(EStageID.BubbleW4, 0x00f4b8, new Int32[] { 9, 10, 13 })); // Bank 4
             RoomGroups.Add(new SpriteBankRoomGroup(EStageID.BubbleW4, 0x00f4ca, new Int32[] { 15, 17 }, // Bank 5


### PR DESCRIPTION
**Jank # 1 - tile rows**

Just needed to make the lasers use the restricted rows system. Try seed `89374890703718651484` with custom sprites *off* to see an example. Without this patch, Sniper Joe should spawn with the lasers and jank them up.

Same applies to the water splash effect.

**Jank # 2 - sprite palettes**

I added extra addresses to the Quick Man ColorSets to make sure they would patch the laser sprite palette with the same values. It took me a while to realize this, but you don't do sprite palette randomization *at all;* if that ever gets added, this solution will have to be revised.

The water splash effect uses the white color from Mega Man's face palette, so it's not really worth it to try and sync that up with the BG colors.