### PR TITLE
Implement system for explicit dependencies

### DIFF
--- a/MM2RandoLib/RandomizationContext.cs
+++ b/MM2RandoLib/RandomizationContext.cs
@@ -62,6 +62,26 @@ namespace MM2Randomizer
 
             Progress = in_Progress;
             CancellationToken = in_CancellationToken;
+
+            // With the new explicit dependency system it should be unnecessary to order these. But for safety they are ordered in the order they appeared in Initialize. If it's discovered that there are undocumented dependencies, they need to be made explicit.
+            RandomStages = CreateRandomizer(new RStages());
+            RandomWeaponGet = CreateRandomizer(new RWeaponGet());
+
+            RandomWeaponBehavior = CreateRandomizer(new RWeaponBehavior());
+            RandomWeaknesses = CreateRandomizer(new RWeaknesses());
+            RandomBossAI = CreateRandomizer(new RBossAI());
+            RandomItemGet = CreateRandomizer(new RItemGet());
+
+            RandomTeleporters = CreateRandomizer(new RTeleporters()); // Out of order for some reason
+
+            RandomEnemies = CreateRandomizer(new REnemies());
+            RandomEnemyWeakness = CreateRandomizer(new REnemyWeaknesses());
+            RandomBossInBossRoom = CreateRandomizer(new RBossRoom());
+            RandomTilemap = CreateRandomizer(new RTilemap());
+
+            RandomColors = CreateCosmeticRandomizer(new RColors());
+            RandomMusic = CreateCosmeticRandomizer(new RMusic());
+            RandomInGameText = CreateCosmeticRandomizer(new RText());
         }
 
         //
@@ -88,6 +108,9 @@ namespace MM2Randomizer
         public Patch Patch { get; private set; } = new Patch();
 
         public ResourceTree ResourceTree { get; } = new(null, "Resources");
+
+        public List<Randomizer> GameplayRandomizers = new();
+        public List<Randomizer> CosmeticRandomizers = new();
 
         /// <summary>
         /// Quality of life hack: if InvisiPico, do NOT randomize Pico movement.
@@ -118,55 +141,58 @@ namespace MM2Randomizer
         // "CORE" MODULES
         //================
 
-        // NOTE: Just in case, link RStages, RWeaponGet, and RTeleporter into one "Core Randomizer" module
-        // Their interdependencies are too risky to separate as options, and likely nobody will want to customize this part anyways.
-        // Random portrait locations on stage select
-        public RStages RandomStages { get; private set; } = new RStages();
-        // Random weapon awarded from each stage
-        // WARNING: May be dependent on RTeleporters, verify?
-        // WARNING: May be dependent on RStages
-        public RWeaponGet RandomWeaponGet { get; private set; } = new RWeaponGet();
-        // Random teleporter destinations in Wily 5
-        public RTeleporters RandomTeleporters { get; private set; } = new RTeleporters();
+        public RStages RandomStages { get; }
+        public RWeaponGet RandomWeaponGet { get; }
+        public RTeleporters RandomTeleporters { get; }
 
 
         ///=========================
         /// "GAMEPLAY SEED" MODULES
         ///=========================
 
-        // Caution: RWeaknesses depends on this
-        public RWeaponBehavior RandomWeaponBehavior { get; private set; } = new RWeaponBehavior();
-        // Depends on RWeaponBehavior (ammo), can use default values
-        public RWeaknesses RandomWeaknesses { get; private set; } = new RWeaknesses();
-        // Independent
-        public RBossAI RandomBossAI { get; private set; } = new RBossAI();
-        // Independent
-        public RItemGet RandomItemGet { get; private set; } = new RItemGet();
-        // Independent
-        public REnemies RandomEnemies { get; private set; } = new REnemies();
-        // Independent
-        public REnemyWeaknesses RandomEnemyWeakness { get; private set; } = new REnemyWeaknesses();
-        // Caution: RText depends on this, but default values will be used if not enabled.
-        public RBossRoom RandomBossInBossRoom { get; private set; } = new RBossRoom();
-        // Independent
-        public RTilemap RandomTilemap { get; private set; } = new RTilemap();
+        public RWeaponBehavior RandomWeaponBehavior { get; }
+        public RWeaknesses RandomWeaknesses { get; }
+        public RBossAI RandomBossAI { get; }
+        public RItemGet RandomItemGet { get; }
+        public REnemies RandomEnemies { get; }
+        public REnemyWeaknesses RandomEnemyWeakness { get; }
+        public RBossRoom RandomBossInBossRoom { get; }
+        public RTilemap RandomTilemap { get; }
 
 
         ///==========================
         /// "COSMETIC SEED" MODULES
         ///==========================
 
-        // Independent
-        public RColors RandomColors { get; private set; } = new RColors();
-        // Independent
-        public RMusic RandomMusic { get; private set; } = new RMusic();
-        // Caution: Depends on RBossRoom, but can use default values if its not enabled.
-        public RText RandomInGameText { get; private set; } = new RText();
+        public RColors RandomColors { get; }
+        public RMusic RandomMusic { get; }
+        public RText RandomInGameText { get; }
+
+
+        //
+        // Dependencies Used by Randomization Modules
+        //
 
 
         //
         // Internal Methods
         //
+
+        private T CreateRandomizer<T>(T in_Randomizer)
+            where T : Randomizer
+        {
+            GameplayRandomizers.Add(in_Randomizer);
+
+            return in_Randomizer;
+        }
+
+        private T CreateCosmeticRandomizer<T>(T in_Randomizer)
+            where T : Randomizer
+        {
+            CosmeticRandomizers.Add(in_Randomizer);
+
+            return in_Randomizer;
+        }
 
         internal async Task Initialize()
         {
@@ -210,61 +236,41 @@ namespace MM2Randomizer
             ParseOptionActions(false);
 
             // List of randomizer modules to use; will add modules based on checkbox states
-            List<IRandomizer> randomizers = new List<IRandomizer>();
-            if (gameplayOpts.RandomizeRobotMasterStageSelection.Value)
-            {
-                randomizers.Add(this.RandomStages);
-            }
-
-            if (gameplayOpts.RandomizeSpecialWeaponReward.Value)
-            {
-                randomizers.Add(this.RandomWeaponGet);
-            }
-
-            if (gameplayOpts.RandomizeSpecialWeaponBehavior.Value)
-            {
-                randomizers.Add(this.RandomWeaponBehavior);
-            }
-
-            if (gameplayOpts.RandomizeBossWeaknesses.Value)
-            {
-                randomizers.Add(this.RandomWeaknesses);
-            }
-
-            if (gameplayOpts.RandomizeRobotMasterBehavior.Value)
-            {
-                randomizers.Add(this.RandomBossAI);
-            }
-
-            if (gameplayOpts.RandomizeSpecialItemLocations.Value)
-            {
-                randomizers.Add(this.RandomItemGet);
-            }
-
-            if (gameplayOpts.RandomizeRefightTeleporters.Value)
-            {
-                randomizers.Add(this.RandomTeleporters);
-            }
-
-            if (gameplayOpts.RandomizeEnemySpawns.Value)
-            {
-                randomizers.Add(this.RandomEnemies);
-            }
-
-            if (gameplayOpts.RandomizeEnemyWeaknesses.Value)
-            {
-                randomizers.Add(this.RandomEnemyWeakness);
-            }
+            HashSet<Randomizer> randomizers = new(ReferenceEqualityComparer.Instance);
+            HashSet<string> products = new();
 
             if (gameplayOpts.RandomizeRobotMasterLocations.Value)
-            {
                 randomizers.Add(this.RandomBossInBossRoom);
-            }
+
+            if (gameplayOpts.RandomizeRobotMasterStageSelection.Value)
+                randomizers.Add(this.RandomStages);
+
+            if (gameplayOpts.RandomizeSpecialWeaponReward.Value)
+                randomizers.Add(this.RandomWeaponGet);
+
+            if (gameplayOpts.RandomizeSpecialWeaponBehavior.Value)
+                randomizers.Add(this.RandomWeaponBehavior);
+
+            if (gameplayOpts.RandomizeBossWeaknesses.Value)
+                randomizers.Add(this.RandomWeaknesses);
+
+            if (gameplayOpts.RandomizeRobotMasterBehavior.Value)
+                randomizers.Add(this.RandomBossAI);
+
+            if (gameplayOpts.RandomizeSpecialItemLocations.Value)
+                randomizers.Add(this.RandomItemGet);
+
+            if (gameplayOpts.RandomizeRefightTeleporters.Value)
+                randomizers.Add(this.RandomTeleporters);
+
+            if (gameplayOpts.RandomizeEnemySpawns.Value)
+                randomizers.Add(this.RandomEnemies);
+
+            if (gameplayOpts.RandomizeEnemyWeaknesses.Value)
+                randomizers.Add(this.RandomEnemyWeakness);
 
             if (gameplayOpts.RandomizeFalseFloors.Value)
-            {
                 randomizers.Add(this.RandomTilemap);
-            }
 
             // Boss sprites need to be randomized before running normal randomizers because InvisiPico is a special case
             if (spriteOpts.RandomizeBossSprites.Value)
@@ -281,17 +287,12 @@ namespace MM2Randomizer
                     "CheatMode", StringComparison.InvariantCultureIgnoreCase);
             }
 
+            RunRandomizers(GameplayRandomizers, randomizers, products);
+
             // Generate a seed for fair Heat Man
             if (gameplayOpts.FairHeatManDelays.Value)
                 DefineSymbolLines.Add(
                     $".define FAIR_HEAT_MAN_SEED ${Seed.NextUInt8(1, 256):x}");
-
-            // Conduct randomization of behavior options
-            foreach (IRandomizer randomizer in randomizers)
-            {
-                randomizer.Randomize(this.Patch, this);
-                Debug.WriteLine(randomizer);
-            }
 
             ApplyOptionActions();
 
@@ -309,29 +310,19 @@ namespace MM2Randomizer
             ParseOptionActions(true);
 
             // List of randomizer modules to use; will add modules based on checkbox states
-            List<IRandomizer> cosmeticRandomizers = new List<IRandomizer>();
+            HashSet<Randomizer> cosmeticRandomizers = new(ReferenceEqualityComparer.Instance);
 
             if (cosmOpts.RandomizeColorPalettes.Value)
-            {
                 cosmeticRandomizers.Add(this.RandomColors);
-            }
 
             if (cosmOpts.RandomizeMusicTracks.Value)
-            {
                 cosmeticRandomizers.Add(this.RandomMusic);
-            }
 
             if (cosmOpts.RandomizeInGameText.Value)
-            {
                 cosmeticRandomizers.Add(this.RandomInGameText);
-            }
 
             // Conduct randomization of Cosmetic Modules
-            foreach (IRandomizer cosmetic in cosmeticRandomizers)
-            {
-                cosmetic.Randomize(this.Patch, this);
-                Debug.WriteLine(cosmetic);
-            }
+            RunRandomizers(CosmeticRandomizers, cosmeticRandomizers, products);
 
 
             // ================================================
@@ -386,6 +377,48 @@ namespace MM2Randomizer
 
             // Apply patch with randomized content
             this.Patch.ApplyRandoPatch(Rom);
+        }
+
+        private void RunRandomizers(
+            IEnumerable<Randomizer> in_Randomizers,
+            IReadOnlySet<Randomizer> in_EnabledRandomizers,
+            ISet<string> out_Products)
+        {
+            LinkedList<Randomizer> leftToRun = new(in_Randomizers);
+            while (leftToRun.Count != 0)
+            {
+                int numRun = 0;
+                var node = leftToRun.First;
+                while (node != null)
+                {
+                    var rnd = node.Value;
+                    var nextNode = node.Next;
+
+                    if (rnd.Dependencies.All(d => out_Products.Contains(d)))
+                    {
+                        if (in_EnabledRandomizers.Contains(rnd))
+                        {
+                            rnd.Randomize(Patch, this);
+                            Debug.WriteLine(rnd);
+                        }
+                        else
+                            rnd.ProduceWithoutRandomization(this);
+
+                        foreach (var prod in rnd.Products)
+                            out_Products.Add(prod);
+
+                        leftToRun.Remove(node);
+                        numRun++;
+                    }
+
+                    node = nextNode;
+                }
+
+                if (numRun == 0)
+                    throw new UnreachableException(
+                        "no randomizer produces the following dependencies: " 
+                            + string.Join(", ", leftToRun.SelectMany(r => r.Dependencies)));
+            }
         }
 
         /// <summary>
@@ -445,13 +478,13 @@ namespace MM2Randomizer
             Rom = PrepatchRom.ToArray();
         }
 
-    /// <summary>
-    /// Duplicate the portions of the tileset that are shared between Wily 2-5. Makes the following modifications:
-    /// Wily 3's copy of 6a10:6e10 (PPU 1600:1a00) is now located at 3f610.
-    /// Wily 4's copy of 6a10:6e10 is now located at 3fa10.
-    /// Wily 5's copy of ac10:ae10 (PPU 1200:1400) is now located at 3fe10.
-    /// </summary>
-    private void CopyWilyTilesets()
+        /// <summary>
+        /// Duplicate the portions of the tileset that are shared between Wily 2-5. Makes the following modifications:
+        /// Wily 3's copy of 6a10:6e10 (PPU 1600:1a00) is now located at 3f610.
+        /// Wily 4's copy of 6a10:6e10 is now located at 3fa10.
+        /// Wily 5's copy of ac10:ae10 (PPU 1200:1400) is now located at 3fe10.
+        /// </summary>
+        private void CopyWilyTilesets()
         {
             /* All stages have a list of regions to copy to VRAM at start (this includes both sprites at PPU 0:1000 and background at 1000:2000). For Wily 1-6 these lists are at bd00 of bank # - 1. The first byte of each list specifies the number of entries, and each entry is a byte triplet AA NN BB where A is the MSB of the ROM address to copy from, N is the number of 256-byte blocks to copy, and B is the 16 KB ROM bank number.
              * The vanilla values of these tables for the background portion, with * and # indicating the portions that need to be duplicated:

--- a/MM2RandoLib/Randomizers/Colors/RColors.cs
+++ b/MM2RandoLib/Randomizers/Colors/RColors.cs
@@ -10,7 +10,7 @@ namespace MM2Randomizer.Randomizers.Colors
     /// <summary>
     /// Stage Color Palette Randomizer
     /// </summary>
-    public class RColors : IRandomizer
+    public class RColors : Randomizer
     {
         //
         // Constructors
@@ -25,7 +25,7 @@ namespace MM2Randomizer.Randomizers.Colors
         // IRandomizer Methods
         //
 
-        public void Randomize(Patch in_Patch, RandomizationContext in_Context)
+        public override void Randomize(Patch in_Patch, RandomizationContext in_Context)
         {
             this.RandomizeStageColors(in_Patch, in_Context);
             this.RandomizeWeaponColors(in_Patch, in_Context);

--- a/MM2RandoLib/Randomizers/Enemies/REnemies.cs
+++ b/MM2RandoLib/Randomizers/Enemies/REnemies.cs
@@ -14,7 +14,7 @@ namespace MM2Randomizer.Randomizers.Enemies
     /// <summary>
     /// Stage Enemy Type Randomizer
     /// </summary>
-    public class REnemies : IRandomizer
+    public class REnemies : Randomizer
     {
         private static readonly Int32 Stage0EnemyYAddress = 0x3810;
         private static readonly Int32 Stage0EnemyIDAddress = 0x3910;
@@ -40,7 +40,7 @@ namespace MM2Randomizer.Randomizers.Enemies
 
         public REnemies() { }
 
-        public void Randomize(Patch in_Patch, RandomizationContext in_Context)
+        public override void Randomize(Patch in_Patch, RandomizationContext in_Context)
         {
             this.EnemyTypes.Clear();
             this.EnemiesByType.Clear();

--- a/MM2RandoLib/Randomizers/Enemies/REnemyWeaknesses.cs
+++ b/MM2RandoLib/Randomizers/Enemies/REnemyWeaknesses.cs
@@ -9,7 +9,7 @@ using MM2Randomizer.Resources;
 
 namespace MM2Randomizer.Randomizers.Enemies
 {
-    public class REnemyWeaknesses : IRandomizer
+    public class REnemyWeaknesses : Randomizer
     {
         private readonly static Int32 EnemyDamageAddressP = 0x07E9A8;
         private readonly static Int32 EnemyDamageAddressH = 0x07EA24;
@@ -42,7 +42,7 @@ namespace MM2Randomizer.Randomizers.Enemies
             return debug.ToString();
         }
 
-        public void Randomize(Patch in_Patch, RandomizationContext in_Context)
+        public override void Randomize(Patch in_Patch, RandomizationContext in_Context)
         {
             EnemyWeaknessSet enemyWeaknessSet = in_Context.ResourceTree.LoadUtf8Resource("EnemyWeaknessSet.xml").Deserialize<EnemyWeaknessSet>();
 

--- a/MM2RandoLib/Randomizers/IRandomizer.cs
+++ b/MM2RandoLib/Randomizers/IRandomizer.cs
@@ -1,9 +1,0 @@
-﻿using MM2Randomizer.Patcher;
-
-namespace MM2Randomizer.Randomizers
-{
-    public interface IRandomizer
-    {
-        void Randomize(Patch in_Patch, RandomizationContext in_Context);
-    }
-}

--- a/MM2RandoLib/Randomizers/RBossAI.cs
+++ b/MM2RandoLib/Randomizers/RBossAI.cs
@@ -6,7 +6,7 @@ using MM2Randomizer.Random;
 
 namespace MM2Randomizer.Randomizers
 {
-    public class RBossAI : IRandomizer
+    public class RBossAI : Randomizer
     {
         public enum PicoPicoSpawnModes
         {
@@ -17,7 +17,7 @@ namespace MM2Randomizer.Randomizers
 
         public RBossAI() { }
 
-        public void Randomize(Patch in_Patch, RandomizationContext in_Context)
+        public override void Randomize(Patch in_Patch, RandomizationContext in_Context)
         {
             this.ChangeHeat(in_Patch, in_Context.Seed);
             this.ChangeAir(in_Patch, in_Context.Seed);

--- a/MM2RandoLib/Randomizers/RBossRoom.cs
+++ b/MM2RandoLib/Randomizers/RBossRoom.cs
@@ -5,7 +5,7 @@ using MM2Randomizer.Patcher;
 
 namespace MM2Randomizer.Randomizers
 {
-    public class RBossRoom : IRandomizer
+    public class RBossRoom : Randomizer
     {
         private readonly StringBuilder debug = new();
         public override String ToString()
@@ -43,6 +43,7 @@ namespace MM2Randomizer.Randomizers
         }
         
         public RBossRoom()
+            : base(null, [nameof(RBossRoom)])
         {
 
             debug = new();
@@ -212,7 +213,7 @@ namespace MM2Randomizer.Randomizers
         /// <summary>
         /// Shuffle which Robot Master awards which weapon.
         /// </summary>
-        public void Randomize(Patch in_Patch, RandomizationContext in_Context)
+        public override void Randomize(Patch in_Patch, RandomizationContext in_Context)
         {
             IList<BossRoomRandomComponent> bossRoomComponents = in_Context.Seed.Shuffle(this.Components);
 
@@ -282,5 +283,8 @@ namespace MM2Randomizer.Randomizers
                 debug.AppendLine($"{originalName} boss room has {newName} man");
             }
         }
+
+        public override void ProduceWithoutRandomization(RandomizationContext in_Context)
+        { }
     }
 }

--- a/MM2RandoLib/Randomizers/RItemGet.cs
+++ b/MM2RandoLib/Randomizers/RItemGet.cs
@@ -7,7 +7,7 @@ using MM2Randomizer.Patcher;
 
 namespace MM2Randomizer.Randomizers
 {
-    public class RItemGet : IRandomizer
+    public class RItemGet : Randomizer
     {
         private readonly StringBuilder debug = new();
         public override String ToString()
@@ -23,7 +23,7 @@ namespace MM2Randomizer.Randomizers
         /// <summary>
         /// Shuffle which Robot Master awards Items 1, 2, and 3.
         /// </summary>
-        public void Randomize(Patch in_Patch, RandomizationContext in_Context)
+        public override void Randomize(Patch in_Patch, RandomizationContext in_Context)
         {
             // 0x03C291 - Item # from Heat Man
             // 0x03C292 - Item # from Air Man

--- a/MM2RandoLib/Randomizers/RMusic.cs
+++ b/MM2RandoLib/Randomizers/RMusic.cs
@@ -469,7 +469,7 @@ public class Mm2Importer : Importer
     }
 }
 
-public class RMusic : IRandomizer
+public class RMusic : Randomizer
 {
     /// <summary>
     /// Map of which game songs belong to which music uses.
@@ -497,7 +497,7 @@ public class RMusic : IRandomizer
         return debug.ToString();
     }
 
-    public void Randomize(Patch in_Patch, RandomizationContext in_Context)
+    public override void Randomize(Patch in_Patch, RandomizationContext in_Context)
     {
         debug.AppendLine();
         debug.AppendLine("Random Music Module");

--- a/MM2RandoLib/Randomizers/RTeleporters.cs
+++ b/MM2RandoLib/Randomizers/RTeleporters.cs
@@ -6,11 +6,11 @@ using MM2Randomizer.Utilities;
 
 namespace MM2Randomizer.Randomizers
 {
-    public class RTeleporters : IRandomizer
+    public class RTeleporters : Randomizer
     {
         public RTeleporters() { }
 
-        public void Randomize(Patch in_Patch, RandomizationContext in_Context)
+        public override void Randomize(Patch in_Patch, RandomizationContext in_Context)
         {
             // Create list of default teleporter position values
             List<Position> DEFAULT_TELEPORTER_POSITIONS = new List<Position>

--- a/MM2RandoLib/Randomizers/RText.cs
+++ b/MM2RandoLib/Randomizers/RText.cs
@@ -11,13 +11,14 @@ using MM2Randomizer.Utilities;
 
 namespace MM2Randomizer.Randomizers
 {
-    public class RText : IRandomizer
+    public class RText : Randomizer
     {
         //
         // Constructor
         //
 
         public RText()
+            : base([nameof(RBossRoom)])
         {
         }
 
@@ -26,7 +27,7 @@ namespace MM2Randomizer.Randomizers
         // IRandomizer Methods
         //
 
-        public void Randomize(Patch in_Patch, RandomizationContext in_Context)
+        public override void Randomize(Patch in_Patch, RandomizationContext in_Context)
         {
             CompanyNameSet companyNameSet = Properties.Resources.CompanyNameConfig.Deserialize<CompanyNameSet>();
             IEnumerable<CompanyName> enabledCompanyNames = companyNameSet.Where(x => true == x.Enabled);

--- a/MM2RandoLib/Randomizers/RTilemap.cs
+++ b/MM2RandoLib/Randomizers/RTilemap.cs
@@ -4,12 +4,12 @@ using MM2Randomizer.Random;
 
 namespace MM2Randomizer.Randomizers
 {
-    public class RTilemap : IRandomizer
+    public class RTilemap : Randomizer
     {
         public RTilemap() { }
 
 
-        public void Randomize(Patch in_Patch, RandomizationContext in_Context)
+        public override void Randomize(Patch in_Patch, RandomizationContext in_Context)
         {
             //ReadLevelComponentJSON(p, r);
 

--- a/MM2RandoLib/Randomizers/RWeaknesses.cs
+++ b/MM2RandoLib/Randomizers/RWeaknesses.cs
@@ -8,7 +8,7 @@ using MM2Randomizer.Random;
 
 namespace MM2Randomizer.Randomizers
 {
-    public class RWeaknesses : IRandomizer
+    public class RWeaknesses : Randomizer
     {
         // Robot Master damage table. If RWeaknesses module is not enabled, these default values will be used.
         //           P H A W B F Q M C
@@ -246,9 +246,11 @@ namespace MM2Randomizer.Randomizers
             return debug.ToString();
         }
 
-        public RWeaknesses() { }
+        public RWeaknesses()
+            : base([nameof(RWeaponBehavior)])
+        { }
 
-        public void Randomize(Patch in_Patch, RandomizationContext in_Context)
+        public override void Randomize(Patch in_Patch, RandomizationContext in_Context)
         {
             debug = new StringBuilder();
             RandomizeU(in_Patch, in_Context.Seed);

--- a/MM2RandoLib/Randomizers/RWeaponBehavior.cs
+++ b/MM2RandoLib/Randomizers/RWeaponBehavior.cs
@@ -8,7 +8,7 @@ using MM2Randomizer.Random;
 
 namespace MM2Randomizer.Randomizers
 {
-    public class RWeaponBehavior : IRandomizer
+    public class RWeaponBehavior : Randomizer
     {
         // Buster Heat Air Wood Bubble Quick Metal Crash
         private static IDictionary<EWeaponIndex, Double> AmmoUsage = new Dictionary<EWeaponIndex, Double>()
@@ -41,6 +41,7 @@ namespace MM2Randomizer.Randomizers
         }
 
         public RWeaponBehavior()
+            : base(null, [nameof(RWeaponBehavior)])
         {
         }
 
@@ -77,7 +78,7 @@ namespace MM2Randomizer.Randomizers
             });
         }
 
-        public void Randomize(Patch in_Patch, RandomizationContext in_Context)
+        public override void Randomize(Patch in_Patch, RandomizationContext in_Context)
         {
             debug.Clear();
             List<ESoundID> sounds = GetSoundList();

--- a/MM2RandoLib/Randomizers/RWeaponGet.cs
+++ b/MM2RandoLib/Randomizers/RWeaponGet.cs
@@ -7,7 +7,7 @@ using MM2Randomizer.Patcher;
 
 namespace MM2Randomizer.Randomizers
 {
-    public class RWeaponGet : IRandomizer
+    public class RWeaponGet : Randomizer
     {
         private Dictionary<EBossIndex, ERMWeaponValueBit> mNewWeaponOrder;
 
@@ -36,7 +36,7 @@ namespace MM2Randomizer.Randomizers
         /// <summary>
         /// Shuffle which Robot Master awards which weapon.
         /// </summary>
-        public void Randomize(Patch in_Patch, RandomizationContext in_Context)
+        public override void Randomize(Patch in_Patch, RandomizationContext in_Context)
         {
             // StageBeat    Address    Value
             // -----------------------------

--- a/MM2RandoLib/Randomizers/Randomizer.cs
+++ b/MM2RandoLib/Randomizers/Randomizer.cs
@@ -1,0 +1,41 @@
+﻿using MM2Randomizer.Patcher;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MM2Randomizer.Randomizers;
+
+public abstract class Randomizer
+{
+    // Dependencies are things that must be produced before this randomizer runs, and Products are things produced by this randomizer that may be dependencies of other randomizers. By convention both refer to fields of RandomizationContext that should be referenced using nameof, though legacy randomizers that aren't updated to pass info this way could use their own name.
+    public IReadOnlyList<string> Dependencies { get; }
+    public IReadOnlyList<string> Products { get; }
+
+    public Randomizer(IEnumerable<string>? dependencies = null, IEnumerable<string>? products = null)
+    {
+        Dependencies = dependencies != null
+            ? dependencies.ToArray()
+            : Array.Empty<string>();
+        Products = products != null
+            ? products.ToArray() 
+            : Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// Called to apply the randomizer.
+    /// </summary>
+    /// <param name="in_Patch"></param>
+    /// <param name="in_Context"></param>
+    public abstract void Randomize(Patch in_Patch, RandomizationContext in_Context);
+
+    /// <summary>
+    /// Called when the randomizer is not enabled. Must generate any products of the randomizer so that randomizers that depend on these products will work correctly.
+    /// </summary>
+    /// <param name="in_Context"></param>
+    /// <exception cref="Exception"></exception>
+    public virtual void ProduceWithoutRandomization(RandomizationContext in_Context)
+    {
+        if (Products.Count != 0)
+            throw new Exception($"Randomizer.ProduceWithoutRandomization must be overridden in {this.GetType().Name}");
+    }
+}

--- a/MM2RandoLib/Randomizers/Stages/RStages.cs
+++ b/MM2RandoLib/Randomizers/Stages/RStages.cs
@@ -9,7 +9,7 @@ using MM2Randomizer.Settings.Options;
 
 namespace MM2Randomizer.Randomizers.Stages
 {
-    public class RStages : IRandomizer
+    public class RStages : Randomizer
     {
         private List<StageFromSelect>? StageSelect;
         private StringBuilder debug = new StringBuilder();
@@ -141,7 +141,7 @@ namespace MM2Randomizer.Randomizers.Stages
         /// <summary>
         /// Shuffle the Robot Master stages.  This shuffling will not be indicated by the Robot Master portraits.
         /// </summary>
-        public void Randomize(Patch in_Patch, RandomizationContext in_Context)
+        public override void Randomize(Patch in_Patch, RandomizationContext in_Context)
         {
 
             StageSelect = VanillaStageSelect();


### PR DESCRIPTION
Some IRandomizers depend on the outputs of other IRandomizers. Currently these dependencies are documented in comments, and the order randomizers are run is hand-written to meet these requirements. This PR changes this system so dependencies are explicitly specified and enforced in code, and also introduces a cleaner mechanism of sharing data between randomizers. This may potentially change the order randomizers are run, and if there are any undocumented dependencies there may be bugs to fix.

Specifically, each randomizer class now has a set of dependencies and products. When a randomizer is applied its products are produced, which may then be dependencies of other randomizers. The code ensures that the randomizers are applied in the order to ensure this.  For legacy code these products are the randomizers themselves (simply ensuring they execute in order). Going forward the products are shared data in RandomizationContext that one randomizer produces that others may depend on, making it explicit what each depends on.