### PR TITLE
Fix robot master damage table displays

### DIFF
--- a/MM2RandoLib/RandomizationContext.cs
+++ b/MM2RandoLib/RandomizationContext.cs
@@ -173,6 +173,9 @@ namespace MM2Randomizer
         // Dependencies Used by Randomization Modules
         //
 
+        public EBossIndex[] StageBosses { get; set; } = Array.Empty<EBossIndex>();
+        public EStageID[] BossStages { get; set; } = Array.Empty<EStageID>();
+
 
         //
         // Internal Methods

--- a/MM2RandoLib/Randomizers/RBossRoom.cs
+++ b/MM2RandoLib/Randomizers/RBossRoom.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using MM2Randomizer.Enums;
 using MM2Randomizer.Patcher;
 
 namespace MM2Randomizer.Randomizers
@@ -43,7 +45,7 @@ namespace MM2Randomizer.Randomizers
         }
         
         public RBossRoom()
-            : base(null, [nameof(RBossRoom)])
+            : base(null, [nameof(RandomizationContext.BossStages), nameof(RandomizationContext.StageBosses)])
         {
 
             debug = new();
@@ -270,6 +272,15 @@ namespace MM2Randomizer.Randomizers
 
             this.Components = bossRoomComponents;
 
+            in_Context.BossStages = new EStageID[bossRoomComponents.Count];
+            in_Context.StageBosses = new EBossIndex[bossRoomComponents.Count];
+            for (int i = 0; i < bossRoomComponents.Count; i++)
+            {
+                int bossIdx = bossRoomComponents[i].OriginalBossIndex;
+                in_Context.BossStages[bossIdx] = (EStageID)i;
+                in_Context.StageBosses[i] = EBossIndex.All[bossIdx];
+            }
+
             // Dump the boss rooms to the log
             debug.AppendLine("BossRoom Table:");
             debug.AppendLine("-------------------------------------");
@@ -285,6 +296,10 @@ namespace MM2Randomizer.Randomizers
         }
 
         public override void ProduceWithoutRandomization(RandomizationContext in_Context)
-        { }
+        {
+            in_Context.StageBosses = EBossIndex.RobotMasters.ToArray();
+            in_Context.BossStages = EBossIndex.RobotMasters
+                .Select(i => (EStageID)i.Offset).ToArray();
+        }
     }
 }

--- a/MM2RandoLib/Randomizers/RText.cs
+++ b/MM2RandoLib/Randomizers/RText.cs
@@ -18,7 +18,7 @@ namespace MM2Randomizer.Randomizers
         //
 
         public RText()
-            : base([nameof(RBossRoom)])
+            : base([nameof(RandomizationContext.BossStages)])
         {
         }
 
@@ -307,25 +307,10 @@ namespace MM2Randomizer.Randomizers
             {
                 sb = new StringBuilder();
 
-                // Since weaknesses are for the "Room", and the room bosses were shuffled,
-                // obtain the weakness for the boss at this room
-                // TODO: Optimize this mess; when the bossroom is shuffled it should save
-                // a mapping that could be reused here.
-                EBossIndex newIndex = i;
-                for (Int32 m = 0; m < in_Context.RandomBossInBossRoom.Components.Count; m++)
-                {
-                    RBossRoom.BossRoomRandomComponent room = in_Context.RandomBossInBossRoom.Components[m];
-
-                    if (room.OriginalBossIndex == i.Offset)
-                    {
-                        newIndex = i;
-                        break;
-                    }
-                }
-
+                var stgIdx = EBossIndex.All[(int)in_Context.BossStages[i.Offset]];
                 foreach (EWeaponIndex j in EWeaponIndex.All)
                 {
-                    Int32 dmg = RWeaknesses.BotWeaknesses[newIndex][j];
+                    Int32 dmg = RWeaknesses.BotWeaknesses[stgIdx][j];
                     sb.Append($"{RText.GetBossWeaknessDamageChar(dmg)} ");
                 }
 

--- a/MM2RandoLib/Randomizers/RWeaknesses.cs
+++ b/MM2RandoLib/Randomizers/RWeaknesses.cs
@@ -247,13 +247,13 @@ namespace MM2Randomizer.Randomizers
         }
 
         public RWeaknesses()
-            : base([nameof(RWeaponBehavior)])
+            : base([nameof(RWeaponBehavior), nameof(RandomizationContext.BossStages)])
         { }
 
         public override void Randomize(Patch in_Patch, RandomizationContext in_Context)
         {
             debug = new StringBuilder();
-            RandomizeU(in_Patch, in_Context.Seed);
+            RandomizeU(in_Patch, in_Context, in_Context.Seed);
             RandomizeWilyUJ(
                 in_Patch, 
                 in_Context.Seed, 
@@ -263,7 +263,7 @@ namespace MM2Randomizer.Randomizers
         /// <summary>
         /// Identical to RandomWeaknesses() but using Mega Man 2 (U).nes offsets
         /// </summary>
-        private void RandomizeU(Patch in_Patch, ISeed in_Seed)
+        private void RandomizeU(Patch in_Patch, RandomizationContext in_Context, ISeed in_Seed)
         {
             Dictionary<EWeaponIndex, EDmgVsBoss> bossPrimaryWeaknessAddresses = EDmgVsBoss.GetTables(includeBuster: false, includeTimeStopper: true);
             Dictionary<EBossIndex, EDmgVsBoss> bossWeaknessShuffled = bossPrimaryWeaknessAddresses
@@ -382,18 +382,17 @@ namespace MM2Randomizer.Randomizers
                 }
             }
 
-            // TODO: Fix this debug output, it's incorrect. It corresponds to the stages, not bosses. Needs
-            // to be permuted based on random bosses in boss room.
             debug.AppendLine("Robot Master Weaknesses:");
             debug.AppendLine("P\tH\tA\tW\tB\tQ\tF\tM\tC:");
             debug.AppendLine("--------------------------------------------");
-            foreach(EBossIndex i in BotWeaknesses.Keys)
+            foreach (EBossIndex bossIdx in BotWeaknesses.Keys)
             {
+                EBossIndex stageIdx = EBossIndex.All[(int)in_Context.BossStages[bossIdx.Offset]];
                 foreach(EWeaponIndex j in EWeaponIndex.All)
                 {
-                    debug.Append(String.Format("{0}\t", BotWeaknesses[i][j]));
+                    debug.Append(String.Format("{0}\t", BotWeaknesses[stageIdx][j]));
                 }
-                debug.AppendLine("< " + ((EDmgVsBoss.Offset)i).ToString());
+                debug.AppendLine("< " + bossIdx.Name);
             }
             debug.Append(Environment.NewLine);
 


### PR DESCRIPTION
Fix the order of the boss weakness table when boss room shuffle is enabled.