### PR TITLE
fix inconsistent gameplay results if Randomize Boss Sprites is checked

### DIFF
--- a/MM2RandoLib/RandomizationContext.cs
+++ b/MM2RandoLib/RandomizationContext.cs
@@ -290,6 +290,9 @@ namespace MM2Randomizer
                     "CheatMode", StringComparison.InvariantCultureIgnoreCase);
             }
 
+            // Need to reset the seed after that little shenanigan to ensure consistent gameplay results regardless of cosmetic settings
+            Seed.Reset();
+
             RunRandomizers(GameplayRandomizers, randomizers, products);
 
             // Generate a seed for fair Heat Man


### PR DESCRIPTION
This all has to do with InvisiPico. Boss cosmetics are run early so we can check if the invisible Picopico graphics were selected, then  later ensure we don't randomize the spawn patterns. This will alter the results of all other gameplay rolls unless something is done to keep the seed in sync, i.e., `.Reset()`.

I had another approach where I "wasted" 16 `.Next()` calls to sync up with the number of bosses, and that worked, too. If you're leery of resetting the seed, I could do that.

Here's a sample movie that syncs with and without sprite customization: https://www.youtube.com/watch?v=bKTlR9ekjnY