### PR TITLE
Fix Randomizer Development Link

### DIFF
--- a/RandomizerHost.Common/Views/MainView.axaml
+++ b/RandomizerHost.Common/Views/MainView.axaml
@@ -574,7 +574,7 @@
                            TextDecorations="Underline"
                            Foreground="CornflowerBlue"
                            Cursor="Hand"
-                           PointerPressed="DiscordLink_PointerPressed"/>
+                           PointerPressed="WikiLink_PointerPressed"/>
                 <TextBlock Text="Discord"
                            HorizontalAlignment="Center"
                            FontWeight="Bold"


### PR DESCRIPTION
Was previously linking to Discord due to a copy/paste/change mistake. 

Change PointerPressed event to "WikiLink"