### PR TITLE
Generate randomizer seeds based on the class name

### DIFF
--- a/MM2RandoLib/RandomizationContext.cs
+++ b/MM2RandoLib/RandomizationContext.cs
@@ -80,29 +80,33 @@ namespace MM2Randomizer
             RandomTilemap = CreateRandomizer(new RTilemap());
 
             RandomFairHeatManDelay = CreateRandomizer(
-                new RandomizerFunction((p, c) =>
-                {
-                    // Generate a seed for fair Heat Man
-                    DefineSymbolLines.Add(
-                        $".define FAIR_HEAT_MAN_SEED ${c.Seed.NextUInt8(1, 256):x}");
-                }));
+                new RandomizerFunction(
+                    "GenerateFairHeatManSeed",
+                    (p, c) =>
+                    {
+                        // Generate a seed for fair Heat Man
+                        DefineSymbolLines.Add(
+                            $".define FAIR_HEAT_MAN_SEED ${c.Seed.NextUInt8(1, 256):x}");
+                    }));
 
             RandomBossSprites = CreateRandomizer(
-                new RandomizerFunction((p, c) =>
-                {
-                    var bossPatches = MiscHacks.ApplyOneIpsPerDir(
-                        this, "SpritePatches.Bosses");
-                    var bossSprites = bossPatches
-                        .Where(kv => BossDirNames.ContainsKey(kv.Key.Name))
-                        .ToDictionary(kv => BossDirNames[kv.Key.Name], kv => kv.Value);
+                new RandomizerFunction(
+                    "RandomizeBossSprites",
+                    (p, c) =>
+                    {
+                        var bossPatches = MiscHacks.ApplyOneIpsPerDir(
+                            this, "SpritePatches.Bosses");
+                        var bossSprites = bossPatches
+                            .Where(kv => BossDirNames.ContainsKey(kv.Key.Name))
+                            .ToDictionary(kv => BossDirNames[kv.Key.Name], kv => kv.Value);
 
-                    // Very hacky. But I'm not sure what a better way to do it would be.
-                    var picoNode = bossSprites[EBossIndex.Pico];
-                    c.IsInvisiPico = picoNode is not null && picoNode.Name.Contains(
-                        "CheatMode", StringComparison.InvariantCultureIgnoreCase);
-                },
-                c => { },
-                products: ["IsInvisiPico"]));
+                        // Very hacky. But I'm not sure what a better way to do it would be.
+                        var picoNode = bossSprites[EBossIndex.Pico];
+                        c.IsInvisiPico = picoNode is not null && picoNode.Name.Contains(
+                            "CheatMode", StringComparison.InvariantCultureIgnoreCase);
+                    },
+                    c => { },
+                    products: ["IsInvisiPico"]));
 
             RandomColors = CreateCosmeticRandomizer(new RColors());
             RandomMusic = CreateCosmeticRandomizer(new RMusic());
@@ -418,7 +422,7 @@ namespace MM2Randomizer
 
                     if (rnd.Dependencies.All(d => out_Products.Contains(d)))
                     {
-                        Seed = new PcgSeed(rootSeed.NextInt32().ToString());
+                        Seed = new PcgSeed(rootSeed.Identifier + rnd.Name);
 
                         if (in_EnabledRandomizers.Contains(rnd))
                         {

--- a/MM2RandoLib/Randomizers/Randomizer.cs
+++ b/MM2RandoLib/Randomizers/Randomizer.cs
@@ -7,11 +7,16 @@ namespace MM2Randomizer.Randomizers;
 
 public abstract class Randomizer
 {
+    // Every randomizer module must have a unique name
+    public virtual string Name => this.GetType().Name;
+
     // Dependencies are things that must be produced before this randomizer runs, and Products are things produced by this randomizer that may be dependencies of other randomizers. By convention both refer to fields of RandomizationContext that should be referenced using nameof, though legacy randomizers that aren't updated to pass info this way could use their own name.
     public IReadOnlyList<string> Dependencies { get; }
     public IReadOnlyList<string> Products { get; }
 
-    public Randomizer(IEnumerable<string>? dependencies = null, IEnumerable<string>? products = null)
+    public Randomizer(
+        IEnumerable<string>? dependencies = null, 
+        IEnumerable<string>? products = null)
     {
         Dependencies = dependencies != null
             ? dependencies.ToArray()

--- a/MM2RandoLib/Randomizers/RandomizerFunction.cs
+++ b/MM2RandoLib/Randomizers/RandomizerFunction.cs
@@ -7,13 +7,18 @@ namespace MM2Randomizer.Randomizers;
 
 public class RandomizerFunction : Randomizer
 {
+    public override string Name { get; }
+
     public RandomizerFunction(
+        string name,
         Action<Patch, RandomizationContext> randomize,
         Action<RandomizationContext>? produceWithoutRandomization = null,
         IEnumerable<string>? dependencies = null, 
         IEnumerable<string>? products = null) 
         : base(dependencies, products)
     {
+        Name = name;
+
         RandomizeFunction = randomize;
         ProduceWithoutRandomizationFunction = produceWithoutRandomization;
     }

--- a/MM2RandoLib/Settings/OptionSystem/Option.cs
+++ b/MM2RandoLib/Settings/OptionSystem/Option.cs
@@ -204,8 +204,10 @@ public abstract class Option<T> : IOption
 
     public void Actualize(ISeed seed)
     {
+        // To ensure one option doesn't affect the entire random sequence, always generate a random value even if it's not used.
+        T rndValue = GetRandomizedOption(seed);
         Value = (_override ? _overrideRandomize : _randomize)
-            ? GetRandomizedOption(seed)
+            ? rndValue
             : (_override ? _overrideValue : _baseValue);
     }
 


### PR DESCRIPTION
#290 did not fully fix the problem as options could still modify the seed state before randomizers run. To fix this, stop pulling subseeds for the root seed entirely and generate them based on the names of the randomizers. This will ensure randomizers always get the same subseed regardless of any options or order they're applied.