### PR TITLE
fix up Airman cloud palettes

### DIFF
--- a/MM2RandoLib/Enums/EColorsHex.cs
+++ b/MM2RandoLib/Enums/EColorsHex.cs
@@ -77,7 +77,7 @@ namespace MM2Randomizer.Enums
         PastelGreen= 0x3A,
         PastelCyan= 0x3B,
         Cyan= 0x3C,
-        BabyPink= 0x3D,
+        LighterGray= 0x3D,
         Black8= 0x3E,
         Black9= 0x3F
     }

--- a/MM2RandoLib/Randomizers/Colors/RColors.cs
+++ b/MM2RandoLib/Randomizers/Colors/RColors.cs
@@ -1301,7 +1301,6 @@ namespace MM2Randomizer.Randomizers.Colors
                         new EColorsHex[] {  EColorsHex.Yellow, EColorsHex.Yellow },
                         new EColorsHex[] {  EColorsHex.Lime, EColorsHex.Lime },
                         new EColorsHex[] {  EColorsHex.RoyalBlue, EColorsHex.RoyalBlue },
-                        new EColorsHex[] {  EColorsHex.RoyalBlue, EColorsHex.RoyalBlue },
                         new EColorsHex[] {  EColorsHex.DarkGreen, EColorsHex.DarkGreen },
                         new EColorsHex[] {  EColorsHex.Black3, EColorsHex.Black3 },
                     }

--- a/MM2RandoLib/Randomizers/Colors/RColors.cs
+++ b/MM2RandoLib/Randomizers/Colors/RColors.cs
@@ -1271,80 +1271,39 @@ namespace MM2Randomizer.Randomizers.Colors
                 },
                 new ColorSet() { // Air | Clouds 
                     addresses = new Int32[] {
-                        0x7e13, 0x7e14, 0x7e15,
+                        0x7e13, 0x7e14, 0x7e15, // The "unanimated" colors you see briefly before it starts for real.
                         0x7e33, 0x7e43, 0x7e53, 0x7e63,
                         0x7e34, 0x7e44, 0x7e54, 0x7e64,
                         0x7e35, 0x7e45, 0x7e55, 0x7e65 },
                     ColorBytes = new List<EColorsHex[]>() {
+                        // LightVioletRed is a jarring "you shouldn't be able to see this" color.
                         new EColorsHex[] {
-                            EColorsHex.LightBlue,  EColorsHex.PastelBlue,  EColorsHex.White,
-                            EColorsHex.LightBlue,  EColorsHex.PastelBlue,  EColorsHex.White,  EColorsHex.PastelBlue,
-                            EColorsHex.PastelBlue, EColorsHex.White,       EColorsHex.White,  EColorsHex.White,
-                            EColorsHex.White,      EColorsHex.White,       EColorsHex.White,  EColorsHex.White,
+                            EColorsHex.PastelBlue,  EColorsHex.White,       EColorsHex.White,
+                            EColorsHex.White,       EColorsHex.PastelBlue,  EColorsHex.LightVioletRed,  EColorsHex.PastelBlue,
+                            EColorsHex.White,       EColorsHex.White,       EColorsHex.PastelBlue,      EColorsHex.White,
+                            EColorsHex.White,       EColorsHex.White,       EColorsHex.White,           EColorsHex.White,
                         },
                         new EColorsHex[] {
-                            EColorsHex.LightGray,  EColorsHex.LightGray,    EColorsHex.LightGray,
-                            EColorsHex.LightGray,  EColorsHex.Gray,         EColorsHex.DarkRed,     EColorsHex.Gray,
-                            EColorsHex.LightGray,  EColorsHex.LightGray,    EColorsHex.Gray,        EColorsHex.LightGray,
-                            EColorsHex.LightGray,  EColorsHex.LightGray,    EColorsHex.LightGray,   EColorsHex.LightGray,
-                        },
-                        new EColorsHex[] {
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10,
-                            (EColorsHex)0x10, (EColorsHex)0x00, (EColorsHex)0x04, (EColorsHex)0x00,
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x00, (EColorsHex)0x10,
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10,
-                        },
-                        new EColorsHex[] {
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10,
-                            (EColorsHex)0x10, (EColorsHex)0x00, (EColorsHex)0x02, (EColorsHex)0x00,
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x00, (EColorsHex)0x10,
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10,
-                        },
-                        new EColorsHex[] {
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10,
-                            (EColorsHex)0x10, (EColorsHex)0x00, (EColorsHex)0x0c, (EColorsHex)0x00,
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x00, (EColorsHex)0x10,
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10,
-                        },
-                        new EColorsHex[] {
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10,
-                            (EColorsHex)0x10, (EColorsHex)0x00, (EColorsHex)0x0b, (EColorsHex)0x00,
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x00, (EColorsHex)0x10,
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10,
-                        },
-                        new EColorsHex[] {
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10,
-                            (EColorsHex)0x10, (EColorsHex)0x00, (EColorsHex)0x0a, (EColorsHex)0x00,
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x00, (EColorsHex)0x10,
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10,
-                        },
-                        new EColorsHex[] {
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10,
-                            (EColorsHex)0x10, (EColorsHex)0x00, (EColorsHex)0x08, (EColorsHex)0x00,
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x00, (EColorsHex)0x10,
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10,
-                        },
-                        new EColorsHex[] {
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10,
-                            (EColorsHex)0x10, (EColorsHex)0x00, (EColorsHex)0x06, (EColorsHex)0x00,
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x00, (EColorsHex)0x10,
-                            (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10, (EColorsHex)0x10,
+                            EColorsHex.SoftBlue,   EColorsHex.LightGray,  EColorsHex.LightGray,
+                            EColorsHex.LightGray,  EColorsHex.SoftBlue,   EColorsHex.LightVioletRed,  EColorsHex.SoftBlue,
+                            EColorsHex.LightGray,  EColorsHex.LightGray,  EColorsHex.SoftBlue,        EColorsHex.LightGray,
+                            EColorsHex.LightGray,  EColorsHex.LightGray,  EColorsHex.LightGray,       EColorsHex.LightGray,
                         },
                     }
                 },
                 new ColorSet() { // Air | Sky 
-                    addresses = new Int32[] { 0x7e22 },
+                    addresses = new Int32[] { 0x7e22, 0x7e53 }, // Duplicated to target the fringe color in the cloud animation
                     ColorBytes = new List<EColorsHex[]>() {
-                        new EColorsHex[] {  EColorsHex.LightBlue },
-                        new EColorsHex[] {  EColorsHex.LightPurple },
-                        new EColorsHex[] {  EColorsHex.LightOrange },
-                        new EColorsHex[] {  EColorsHex.YellowOrange },
-                        new EColorsHex[] {  EColorsHex.Yellow },
-                        new EColorsHex[] {  EColorsHex.Lime },
-                        new EColorsHex[] {  EColorsHex.RoyalBlue },
-                        new EColorsHex[] {  EColorsHex.RoyalBlue },
-                        new EColorsHex[] {  EColorsHex.DarkGreen },
-                        new EColorsHex[] {  EColorsHex.Black3 },
+                        new EColorsHex[] {  EColorsHex.LightBlue, EColorsHex.LightBlue },
+                        new EColorsHex[] {  EColorsHex.LightPurple, EColorsHex.LightPurple },
+                        new EColorsHex[] {  EColorsHex.LightOrange, EColorsHex.LightOrange },
+                        new EColorsHex[] {  EColorsHex.YellowOrange, EColorsHex.YellowOrange },
+                        new EColorsHex[] {  EColorsHex.Yellow, EColorsHex.Yellow },
+                        new EColorsHex[] {  EColorsHex.Lime, EColorsHex.Lime },
+                        new EColorsHex[] {  EColorsHex.RoyalBlue, EColorsHex.RoyalBlue },
+                        new EColorsHex[] {  EColorsHex.RoyalBlue, EColorsHex.RoyalBlue },
+                        new EColorsHex[] {  EColorsHex.DarkGreen, EColorsHex.DarkGreen },
+                        new EColorsHex[] {  EColorsHex.Black3, EColorsHex.Black3 },
                     }
                 },
 


### PR DESCRIPTION
All the custom cloud palettes were the same medium gray color with a random row 0 color thrown in that didn't match the sky. I've updated the ColorSets to only have one copy of gray (making white clouds much more likely), and altered the sky ColorSet to target the fringe color and keep up the shrinking/billowing effect.

The clouds always use the same blue colors for the fringes. LighterGray (3D) looks fine on the white clouds, but none of the grays look quite right on the LightGray (10) clouds. Of course, feel free to mess around with it.

<img width="256" height="224" alt="cloud_fringe2" src="https://github.com/user-attachments/assets/f5cb011b-51d8-47b7-86dd-dfbe3711f44f" />
<img width="256" height="224" alt="cloud_fringe1" src="https://github.com/user-attachments/assets/acb1f4e4-c0f5-48ae-9b3f-ec948fd9a84a" />

----

This is still an issue, however:

<img width="256" height="224" alt="MM2-RNG-ESNILFRWPMAFGZ (5A92AB4B6BB9B4040EFA)-1" src="https://github.com/user-attachments/assets/726ba498-11e5-4cdf-9f00-a73be23813db" />
